### PR TITLE
Impl while ast

### DIFF
--- a/crates/ast/src/nodes.rs
+++ b/crates/ast/src/nodes.rs
@@ -334,6 +334,17 @@ impl ReturnExpr {
     }
 }
 
+def_ast_node!(WhileExpr);
+impl WhileExpr {
+    pub fn condition(&self) -> Option<Expr> {
+        ast_node::child_node(self)
+    }
+
+    pub fn body(&self) -> Option<BlockExpr> {
+        self.syntax().children().skip(1).find_map(BlockExpr::cast)
+    }
+}
+
 def_ast_node!(FunctionDef);
 impl FunctionDef {
     pub fn params(&self) -> Option<ParamList> {

--- a/crates/lexer/src/token_kind.rs
+++ b/crates/lexer/src/token_kind.rs
@@ -41,6 +41,9 @@ pub enum TokenKind {
     /// `return`
     #[token("return")]
     ReturnKw,
+    /// `while`
+    #[token("while")]
+    WhileKw,
 
     // identifier
     /// `[A-Za-z_][A-Za-z0-9_]*`
@@ -170,6 +173,7 @@ impl fmt::Display for TokenKind {
             Self::IfKw => "'if'",
             Self::ElseKw => "'else'",
             Self::ReturnKw => "'return'",
+            Self::WhileKw => "'while'",
             Self::Ident => "identifier",
             Self::IntegerLiteral => "integerLiteral",
             Self::StringLiteral => "stringLiteral",
@@ -269,6 +273,11 @@ mod tests {
     #[test]
     fn lex_return_keyword() {
         check("return", TokenKind::ReturnKw);
+    }
+
+    #[test]
+    fn lex_while_keyword() {
+        check("while", TokenKind::WhileKw);
     }
 
     #[test]

--- a/crates/parser/src/grammar/stmt.rs
+++ b/crates/parser/src/grammar/stmt.rs
@@ -262,7 +262,7 @@ mod tests {
                     Error@8..10
                       Integer@8..10 "10"
                 error at 8..10: expected '=', but found integerLiteral
-                error at 8..10: expected integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '(', '{', 'if' or 'return'
+                error at 8..10: expected integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '(', '{', 'if', 'return' or 'while'
             "#]],
         )
     }
@@ -309,7 +309,7 @@ mod tests {
                       Path@16..17
                         PathSegment@16..17
                           Ident@16..17 "a"
-                error at 8..11: expected integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '(', '{', 'if' or 'return', but found 'let'
+                error at 8..11: expected integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '(', '{', 'if', 'return' or 'while', but found 'let'
             "#]],
         );
     }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -160,7 +160,7 @@ mod tests {
                               Ident@11..16 "hello"
                       Whitespace@16..17 " "
                       RCurly@17..18 "}"
-                error at 9..10: expected '}', 'let', 'fn', 'mod', integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '(', '{', 'if' or 'return', but found '/'
+                error at 9..10: expected '}', 'let', 'fn', 'mod', integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '(', '{', 'if', 'return' or 'while', but found '/'
             "#]],
         );
     }

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -65,6 +65,7 @@ pub enum SyntaxKind {
     IfKw,
     ElseKw,
     ReturnKw,
+    WhileKw,
 
     // identifier
     Ident,
@@ -131,6 +132,7 @@ impl From<TokenKind> for SyntaxKind {
             TokenKind::IfKw => Self::IfKw,
             TokenKind::ElseKw => Self::ElseKw,
             TokenKind::ReturnKw => Self::ReturnKw,
+            TokenKind::WhileKw => Self::WhileKw,
 
             TokenKind::Ident => Self::Ident,
 

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -33,6 +33,7 @@ pub enum SyntaxKind {
     ReturnExpr,
     ExprStmt,
     PathExpr,
+    WhileExpr,
 
     // statement nodes
     VariableDef,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- 新機能: `WhileExpr`という新しいASTノードを追加しました。これにより、コード内のwhileループを表現できます。
- 新機能: `TokenKind`列挙型に`WhileKw`トークンを追加しました。これにより、ソースコード内の"while"キーワードを認識できます。
- 新機能: `parse_while`関数を追加し、`while`式のパースが可能になりました。
- テスト: `parse_while`関数のテストケースを追加しました。
- 新機能: `SyntaxKind`列挙型に新しいバリアント`WhileExpr`を追加し、対応する`TokenKind`列挙型に`WhileKw`バリアントを追加しました。これにより、コードベースに新しい構文要素としてwhileループが導入されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->