### PR TITLE
Impl break continue ast

### DIFF
--- a/crates/ast/src/nodes.rs
+++ b/crates/ast/src/nodes.rs
@@ -349,6 +349,15 @@ impl LoopExpr {
     }
 }
 
+def_ast_node!(ContinueExpr);
+
+def_ast_node!(BreakExpr);
+impl BreakExpr {
+    pub fn value(&self) -> Option<Expr> {
+        ast_node::child_node(self)
+    }
+}
+
 def_ast_node!(WhileExpr);
 impl WhileExpr {
     pub fn condition(&self) -> Option<Expr> {

--- a/crates/lexer/src/token_kind.rs
+++ b/crates/lexer/src/token_kind.rs
@@ -44,6 +44,12 @@ pub enum TokenKind {
     /// `loop`
     #[token("loop")]
     LoopKw,
+    /// `continue`
+    #[token("continue")]
+    ContinueKw,
+    /// `break`
+    #[token("break")]
+    BreakKw,
     /// `while`
     #[token("while")]
     WhileKw,
@@ -178,6 +184,8 @@ impl fmt::Display for TokenKind {
             Self::ReturnKw => "'return'",
             Self::LoopKw => "'loop'",
             Self::WhileKw => "'while'",
+            Self::ContinueKw => "'continue'",
+            Self::BreakKw => "'break'",
             Self::Ident => "identifier",
             Self::IntegerLiteral => "integerLiteral",
             Self::StringLiteral => "stringLiteral",
@@ -282,6 +290,16 @@ mod tests {
     #[test]
     fn lex_loop_keyword() {
         check("loop", TokenKind::LoopKw);
+    }
+
+    #[test]
+    fn lex_continue_keyword() {
+        check("continue", TokenKind::ContinueKw);
+    }
+
+    #[test]
+    fn lex_break_keyword() {
+        check("break", TokenKind::BreakKw);
     }
 
     #[test]

--- a/crates/parser/src/grammar/expr.rs
+++ b/crates/parser/src/grammar/expr.rs
@@ -22,9 +22,9 @@ pub(super) const EXPR_FIRST: [TokenKind; 17] = [
     TokenKind::IfKw,
     TokenKind::ReturnKw,
     TokenKind::LoopKw,
-    TokenKind::WhileKw,
     TokenKind::ContinueKw,
     TokenKind::BreakKw,
+    TokenKind::WhileKw,
 ];
 
 /// アイテムの最初に現れる可能性があるトークンの集合

--- a/crates/parser/src/grammar/expr.rs
+++ b/crates/parser/src/grammar/expr.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 /// 式の最初に現れる可能性があるトークンの集合
-pub(super) const EXPR_FIRST: [TokenKind; 15] = [
+pub(super) const EXPR_FIRST: [TokenKind; 17] = [
     TokenKind::StringLiteral,
     TokenKind::CharLiteral(false),
     TokenKind::CharLiteral(true),
@@ -23,6 +23,8 @@ pub(super) const EXPR_FIRST: [TokenKind; 15] = [
     TokenKind::ReturnKw,
     TokenKind::LoopKw,
     TokenKind::WhileKw,
+    TokenKind::ContinueKw,
+    TokenKind::BreakKw,
 ];
 
 /// アイテムの最初に現れる可能性があるトークンの集合
@@ -171,6 +173,10 @@ fn parse_lhs(parser: &mut Parser) -> Option<CompletedNodeMarker> {
         parse_return(parser)
     } else if parser.at(TokenKind::LoopKw) {
         parse_loop(parser)
+    } else if parser.at(TokenKind::ContinueKw) {
+        parse_continue(parser)
+    } else if parser.at(TokenKind::BreakKw) {
+        parse_break(parser)
     } else if parser.at(TokenKind::WhileKw) {
         parse_while(parser)
     } else {
@@ -366,6 +372,30 @@ fn parse_loop(parser: &mut Parser) -> CompletedNodeMarker {
     }
 
     marker.complete(parser, SyntaxKind::LoopExpr)
+}
+
+/// `continue`式のパース
+fn parse_continue(parser: &mut Parser) -> CompletedNodeMarker {
+    assert!(parser.at(TokenKind::ContinueKw));
+
+    let marker = parser.start();
+    parser.bump();
+
+    marker.complete(parser, SyntaxKind::ContinueExpr)
+}
+
+/// `break`式のパース
+fn parse_break(parser: &mut Parser) -> CompletedNodeMarker {
+    assert!(parser.at(TokenKind::BreakKw));
+
+    let marker = parser.start();
+    parser.bump();
+
+    if parser.at_set_no_expected(&EXPR_FIRST) {
+        parse_expr(parser);
+    }
+
+    marker.complete(parser, SyntaxKind::BreakExpr)
 }
 
 /// `while`式のパース
@@ -901,7 +931,7 @@ mod tests {
                         Literal@1..2
                           Integer@1..2 "1"
                         Plus@2..3 "+"
-                error at 2..3: expected integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '(', '{', 'if', 'return', 'loop' or 'while'
+                error at 2..3: expected integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '(', '{', 'if', 'return', 'loop', 'continue', 'break' or 'while'
                 error at 2..3: expected ')'
             "#]],
         );
@@ -1233,7 +1263,7 @@ mod tests {
                     Error@5..6
                       RParen@5..6 ")"
                 error at 4..5: expected '::', '+', '-', '*', '/', '==', '<', '>', ',' or ')', but found identifier
-                error at 5..6: expected '+', '-', '*', '/', '==', '<', '>', ';', 'let', 'fn', 'mod', integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '!', '(', '{', 'if', 'return', 'loop' or 'while', but found ')'
+                error at 5..6: expected '+', '-', '*', '/', '==', '<', '>', ';', 'let', 'fn', 'mod', integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '!', '(', '{', 'if', 'return', 'loop', 'continue', 'break' or 'while', but found ')'
             "#]],
         );
     }
@@ -1891,6 +1921,78 @@ mod tests {
                             Integer@15..17 "30"
                         Whitespace@17..18 " "
                         RCurly@18..19 "}"
+            "#]],
+        );
+    }
+
+    #[test]
+    fn parse_continue() {
+        check_debug_tree_in_block(
+            "loop { continue; }",
+            expect![[r#"
+                SourceFile@0..18
+                  ExprStmt@0..18
+                    LoopExpr@0..18
+                      LoopKw@0..4 "loop"
+                      Whitespace@4..5 " "
+                      BlockExpr@5..18
+                        LCurly@5..6 "{"
+                        Whitespace@6..7 " "
+                        ExprStmt@7..16
+                          ContinueExpr@7..15
+                            ContinueKw@7..15 "continue"
+                          Semicolon@15..16 ";"
+                        Whitespace@16..17 " "
+                        RCurly@17..18 "}"
+            "#]],
+        );
+    }
+
+    #[test]
+    fn parse_break() {
+        check_debug_tree_in_block(
+            "loop { break; }",
+            expect![[r#"
+                SourceFile@0..15
+                  ExprStmt@0..15
+                    LoopExpr@0..15
+                      LoopKw@0..4 "loop"
+                      Whitespace@4..5 " "
+                      BlockExpr@5..15
+                        LCurly@5..6 "{"
+                        Whitespace@6..7 " "
+                        ExprStmt@7..13
+                          BreakExpr@7..12
+                            BreakKw@7..12 "break"
+                          Semicolon@12..13 ";"
+                        Whitespace@13..14 " "
+                        RCurly@14..15 "}"
+            "#]],
+        );
+    }
+
+    #[test]
+    fn parse_break_with_expr() {
+        check_debug_tree_in_block(
+            "loop { break 10; }",
+            expect![[r#"
+                SourceFile@0..18
+                  ExprStmt@0..18
+                    LoopExpr@0..18
+                      LoopKw@0..4 "loop"
+                      Whitespace@4..5 " "
+                      BlockExpr@5..18
+                        LCurly@5..6 "{"
+                        Whitespace@6..7 " "
+                        ExprStmt@7..16
+                          BreakExpr@7..15
+                            BreakKw@7..12 "break"
+                            Whitespace@12..13 " "
+                            Literal@13..15
+                              Integer@13..15 "10"
+                          Semicolon@15..16 ";"
+                        Whitespace@16..17 " "
+                        RCurly@17..18 "}"
             "#]],
         );
     }

--- a/crates/parser/src/grammar/stmt.rs
+++ b/crates/parser/src/grammar/stmt.rs
@@ -262,7 +262,7 @@ mod tests {
                     Error@8..10
                       Integer@8..10 "10"
                 error at 8..10: expected '=', but found integerLiteral
-                error at 8..10: expected integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '(', '{', 'if', 'return', 'loop' or 'while'
+                error at 8..10: expected integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '(', '{', 'if', 'return', 'loop', 'continue', 'break' or 'while'
             "#]],
         )
     }
@@ -309,7 +309,7 @@ mod tests {
                       Path@16..17
                         PathSegment@16..17
                           Ident@16..17 "a"
-                error at 8..11: expected integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '(', '{', 'if', 'return', 'loop' or 'while', but found 'let'
+                error at 8..11: expected integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '(', '{', 'if', 'return', 'loop', 'continue', 'break' or 'while', but found 'let'
             "#]],
         );
     }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -160,7 +160,7 @@ mod tests {
                               Ident@11..16 "hello"
                       Whitespace@16..17 " "
                       RCurly@17..18 "}"
-                error at 9..10: expected '}', 'let', 'fn', 'mod', integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '(', '{', 'if', 'return', 'loop' or 'while', but found '/'
+                error at 9..10: expected '}', 'let', 'fn', 'mod', integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '(', '{', 'if', 'return', 'loop', 'continue', 'break' or 'while', but found '/'
             "#]],
         );
     }

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -34,6 +34,8 @@ pub enum SyntaxKind {
     ExprStmt,
     PathExpr,
     LoopExpr,
+    ContinueExpr,
+    BreakExpr,
     WhileExpr,
 
     // statement nodes

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -69,6 +69,8 @@ pub enum SyntaxKind {
     ReturnKw,
     LoopKw,
     WhileKw,
+    ContinueKw,
+    BreakKw,
 
     // identifier
     Ident,
@@ -137,6 +139,8 @@ impl From<TokenKind> for SyntaxKind {
             TokenKind::ReturnKw => Self::ReturnKw,
             TokenKind::LoopKw => Self::LoopKw,
             TokenKind::WhileKw => Self::WhileKw,
+            TokenKind::ContinueKw => Self::ContinueKw,
+            TokenKind::BreakKw => Self::BreakKw,
 
             TokenKind::Ident => Self::Ident,
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- 新機能: `continue`と`break`のキーワードをサポートする新しいASTノードタイプ(`ContinueExpr`、`BreakExpr`、`WhileExpr`)を追加しました。これにより、ユーザーはより複雑な制御フローを表現することが可能になります。
- 新機能: `continue`と`break`のキーワードを解析するための新しい関数(`parse_continue`、`parse_break`)を追加しました。これにより、これらのキーワードの使用がより正確に解析され、エラーメッセージが改善されます。
- テスト: `continue`と`break`キーワードのレキシングをテストする新しいテストケースを追加しました。これにより、これらのキーワードの解析が正確に行われることを確認できます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->