### PR TITLE
Impl continue break HIR

### DIFF
--- a/crates/ast/src/nodes.rs
+++ b/crates/ast/src/nodes.rs
@@ -97,6 +97,8 @@ pub enum Expr {
     IfExpr(IfExpr),
     ReturnExpr(ReturnExpr),
     LoopExpr(LoopExpr),
+    ContinueExpr(ContinueExpr),
+    BreakExpr(BreakExpr),
     WhileExpr(WhileExpr),
 }
 impl Ast for Expr {}
@@ -114,6 +116,8 @@ impl AstNode for Expr {
                 | SyntaxKind::IfExpr
                 | SyntaxKind::ReturnExpr
                 | SyntaxKind::LoopExpr
+                | SyntaxKind::ContinueExpr
+                | SyntaxKind::BreakExpr
                 | SyntaxKind::WhileExpr
         )
     }
@@ -130,6 +134,8 @@ impl AstNode for Expr {
             SyntaxKind::IfExpr => Self::IfExpr(IfExpr { syntax }),
             SyntaxKind::ReturnExpr => Self::ReturnExpr(ReturnExpr { syntax }),
             SyntaxKind::LoopExpr => Self::LoopExpr(LoopExpr { syntax }),
+            SyntaxKind::ContinueExpr => Self::ContinueExpr(ContinueExpr { syntax }),
+            SyntaxKind::BreakExpr => Self::BreakExpr(BreakExpr { syntax }),
             SyntaxKind::WhileExpr => Self::WhileExpr(WhileExpr { syntax }),
             _ => return None,
         };
@@ -149,6 +155,8 @@ impl AstNode for Expr {
             Expr::IfExpr(it) => it.syntax(),
             Expr::ReturnExpr(it) => it.syntax(),
             Expr::LoopExpr(it) => it.syntax(),
+            Expr::ContinueExpr(it) => it.syntax(),
+            Expr::BreakExpr(it) => it.syntax(),
             Expr::WhileExpr(it) => it.syntax(),
         }
     }

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -579,6 +579,10 @@ pub enum Expr {
         /// ループの本体
         block: ExprId,
     },
+    /// ループを中断し、次の反復処理に進みます。
+    Continue,
+    /// ループを終了します。
+    Break { value: Option<ExprId> },
     /// 解釈できない不明な式です。
     Missing,
 }

--- a/crates/hir/src/name_resolver/module_scope.rs
+++ b/crates/hir/src/name_resolver/module_scope.rs
@@ -461,6 +461,12 @@ impl<'a> ModuleScopesBuilder<'a> {
                 self.build_block(hir_file, current_scope_idx, expr);
             }
             Expr::Loop { block } => self.build_block(hir_file, current_scope_idx, *block),
+            Expr::Continue => (),
+            Expr::Break { value } => {
+                if let Some(value) = value {
+                    self.build_expr(hir_file, current_scope_idx, *value);
+                }
+            }
         }
     }
 

--- a/crates/hir_ty/src/checker.rs
+++ b/crates/hir_ty/src/checker.rs
@@ -152,6 +152,8 @@ impl<'a> FunctionTypeChecker<'a> {
             hir::Expr::Loop { block } => {
                 self.check_expr(*block);
             }
+            hir::Expr::Continue => todo!(),
+            hir::Expr::Break { .. } => todo!(),
             hir::Expr::Missing => (),
         };
     }

--- a/crates/hir_ty/src/inference.rs
+++ b/crates/hir_ty/src/inference.rs
@@ -508,6 +508,8 @@ impl<'a> InferBody<'a> {
                 // TODO: まだbreakがないので、Neverとして扱う
                 Monotype::Never
             }
+            hir::Expr::Continue => todo!(),
+            hir::Expr::Break { .. } => todo!(),
         };
 
         self.type_by_expr.insert(expr_id, ty.clone());

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -675,6 +675,8 @@ mod tests {
 
                     msg
                 }
+                hir::Expr::Continue => todo!(),
+                hir::Expr::Break { .. } => todo!(),
                 hir::Expr::Missing => "<missing>".to_string(),
             }
         }
@@ -768,6 +770,8 @@ mod tests {
 
                     msg
                 }
+                hir::Expr::Continue => todo!(),
+                hir::Expr::Break { .. } => todo!(),
                 hir::Expr::Missing => "<missing>".to_string(),
             }
         }

--- a/crates/mir/src/body.rs
+++ b/crates/mir/src/body.rs
@@ -458,6 +458,8 @@ impl<'a> FunctionLower<'a> {
                 }
             }
             hir::Expr::Loop { .. } => todo!(),
+            hir::Expr::Continue => todo!(),
+            hir::Expr::Break { .. } => todo!(),
             hir::Expr::Missing => unreachable!(),
         }
     }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- 新機能：ループの制御を強化するために、`Continue`と`Break`の新しいバリアントを追加しました。これにより、ループの現在の反復をスキップしたり、ループを終了したりすることが可能になります。
- 新機能：`Continue`と`Break`の表現を適切に処理するためのサポートを追加しました。これにより、ループ内の`continue`と`break`のステートメントが適切に処理されます。
- 注意：`Continue`と`Break`の表現の処理はまだ完全には実装されておらず、今後の開発が必要です。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->