### PR TITLE
Impl loop with continue break typed hir

### DIFF
--- a/crates/dock/src/lib.rs
+++ b/crates/dock/src/lib.rs
@@ -555,12 +555,16 @@ impl Diagnostic {
                     }],
                 }
             }
-            InferenceError::BreakOutsideOfLoop { found_expr } => {
+            InferenceError::BreakOutsideOfLoop { kind, found_expr } => {
                 let text_range = found_expr.text_range(db, source_map);
+                let kind_text = match kind {
+                    hir_ty::BreakKind::Break => "Break",
+                    hir_ty::BreakKind::Continue => "Continue",
+                };
 
                 Diagnostic {
                     file,
-                    title: "Break outside of loop".to_string(),
+                    title: format!("{kind_text} outside of loop"),
                     head_offset: text_range.start().into(),
                     messages: vec![Message {
                         message: "expected in <loop>".to_string(),

--- a/crates/dock/src/lib.rs
+++ b/crates/dock/src/lib.rs
@@ -536,6 +536,25 @@ impl Diagnostic {
                     }],
                 }
             }
+            InferenceError::MismatchedType {
+                expected_ty,
+                found_ty,
+                found_expr,
+            } => {
+                let text_range = found_expr.text_range(db, source_map);
+                let expected_ty = type_to_string(db, expected_ty);
+                let found_ty = type_to_string(db, found_ty);
+
+                Diagnostic {
+                    file,
+                    title: "Mismatched type".to_string(),
+                    head_offset: text_range.start().into(),
+                    messages: vec![Message {
+                        message: format!("expected {expected_ty}, actual: {found_ty}"),
+                        range: (text_range.start().into())..(text_range.end().into()),
+                    }],
+                }
+            }
         }
     }
 }

--- a/crates/dock/src/lib.rs
+++ b/crates/dock/src/lib.rs
@@ -555,6 +555,19 @@ impl Diagnostic {
                     }],
                 }
             }
+            InferenceError::BreakOutsideOfLoop { found_expr } => {
+                let text_range = found_expr.text_range(db, source_map);
+
+                Diagnostic {
+                    file,
+                    title: "Break outside of loop".to_string(),
+                    head_offset: text_range.start().into(),
+                    messages: vec![Message {
+                        message: "expected in <loop>".to_string(),
+                        range: (text_range.start().into())..(text_range.end().into()),
+                    }],
+                }
+            }
         }
     }
 }

--- a/crates/dock/tests/type_check.rs
+++ b/crates/dock/tests/type_check.rs
@@ -201,4 +201,14 @@ mod tests {
     async fn mod_project() {
         check("mod_project").await;
     }
+
+    #[tokio::test]
+    async fn loop_break_mismatch() {
+        check("loop_break_mismatch").await;
+    }
+
+    #[tokio::test]
+    async fn loop_mismatch() {
+        check("loop_mismatch").await;
+    }
 }

--- a/crates/dock/tests/type_check.rs
+++ b/crates/dock/tests/type_check.rs
@@ -211,4 +211,9 @@ mod tests {
     async fn loop_mismatch() {
         check("loop_mismatch").await;
     }
+
+    #[tokio::test]
+    async fn break_outside_of_loop() {
+        check("break_outside_of_loop").await;
+    }
 }

--- a/crates/dock/tests/type_check/break_outside_of_loop/main.nail
+++ b/crates/dock/tests/type_check/break_outside_of_loop/main.nail
@@ -1,0 +1,16 @@
+fn main() {
+  loop {
+  }
+  break;
+}
+
+//---stdout
+//---stderr
+
+// Error: Break outside of loop
+//    ╭─[/{nail}/crates/dock/tests/type_check/break_outside_of_loop/main.nail:4:3]
+//    │
+//  4 │   break;
+//    │   ──┬──  
+//    │     ╰──── expected in <loop>
+// ───╯

--- a/crates/dock/tests/type_check/break_outside_of_loop/main.nail
+++ b/crates/dock/tests/type_check/break_outside_of_loop/main.nail
@@ -2,6 +2,7 @@ fn main() {
   loop {
   }
   break;
+  continue;
 }
 
 //---stdout
@@ -13,4 +14,11 @@ fn main() {
 //  4 │   break;
 //    │   ──┬──  
 //    │     ╰──── expected in <loop>
+// ───╯
+// Error: Continue outside of loop
+//    ╭─[/{nail}/crates/dock/tests/type_check/break_outside_of_loop/main.nail:5:3]
+//    │
+//  5 │   continue;
+//    │   ────┬───  
+//    │       ╰───── expected in <loop>
 // ───╯

--- a/crates/dock/tests/type_check/loop_break_mismatch/main.nail
+++ b/crates/dock/tests/type_check/loop_break_mismatch/main.nail
@@ -1,0 +1,25 @@
+fn main() -> int {
+  loop {
+    break 10;
+    break "aaa";
+    break;
+  }
+}
+
+//---stdout
+//---stderr
+
+// Error: Mismatched type
+//    ╭─[/{nail}/crates/dock/tests/type_check/loop_break_mismatch/main.nail:4:5]
+//    │
+//  4 │     break "aaa";
+//    │     ─────┬─────  
+//    │          ╰─────── expected int, actual: string
+// ───╯
+// Error: Mismatched type
+//    ╭─[/{nail}/crates/dock/tests/type_check/loop_break_mismatch/main.nail:5:5]
+//    │
+//  5 │     break;
+//    │     ──┬──  
+//    │       ╰──── expected int, actual: ()
+// ───╯

--- a/crates/dock/tests/type_check/loop_mismatch/main.nail
+++ b/crates/dock/tests/type_check/loop_mismatch/main.nail
@@ -1,0 +1,18 @@
+fn main() {
+  loop {
+    break 10;
+  }
+}
+
+//---stdout
+//---stderr
+
+// Error: Mismatched type in return value
+//    ╭─[/{nail}/crates/dock/tests/type_check/loop_mismatch/main.nail:2:3]
+//    │
+//  2 │ ╭─▶   loop {
+//    ┆ ┆   
+//  4 │ ├─▶   }
+//    │ │         
+//    │ ╰───────── expected (), actual: int
+// ───╯

--- a/crates/hir/src/name_resolver/module_scope.rs
+++ b/crates/hir/src/name_resolver/module_scope.rs
@@ -460,7 +460,7 @@ impl<'a> ModuleScopesBuilder<'a> {
             Expr::Block(_block) => {
                 self.build_block(hir_file, current_scope_idx, expr);
             }
-            Expr::Loop { block } => self.build_block(hir_file, current_scope_idx, *block),
+            Expr::Loop { block } => self.build_expr(hir_file, current_scope_idx, *block),
             Expr::Continue => (),
             Expr::Break { value } => {
                 if let Some(value) = value {

--- a/crates/hir_ty/src/checker.rs
+++ b/crates/hir_ty/src/checker.rs
@@ -152,8 +152,12 @@ impl<'a> FunctionTypeChecker<'a> {
             hir::Expr::Loop { block } => {
                 self.check_expr(*block);
             }
-            hir::Expr::Continue => todo!(),
-            hir::Expr::Break { .. } => todo!(),
+            hir::Expr::Continue => (),
+            hir::Expr::Break { value } => {
+                if let Some(value) = value {
+                    self.check_expr(*value);
+                }
+            }
             hir::Expr::Missing => (),
         };
     }

--- a/crates/hir_ty/src/inference.rs
+++ b/crates/hir_ty/src/inference.rs
@@ -84,18 +84,20 @@ pub struct Signature {
 
 /// continue/breakのコンテキスト
 struct BreakableContext {
-    /// 最後にbreakした式の型
+    /// 最初にbreakした式の型
     ///
     /// 1回目のbreak, 2回目のbreakで型が同じ必要があるため、、出現した型を保持します。
-    final_ty: Option<Monotype>,
+    first_break_ty: Option<Monotype>,
 }
 impl BreakableContext {
     fn new() -> Self {
-        BreakableContext { final_ty: None }
+        BreakableContext {
+            first_break_ty: None,
+        }
     }
 
     fn set_final_ty(&mut self, ty: Monotype) {
-        self.final_ty = Some(ty);
+        self.first_break_ty = Some(ty);
     }
 }
 
@@ -542,7 +544,7 @@ impl<'a> InferBody<'a> {
                     },
                 );
 
-                let loop_ty = self.current_breakable().unwrap().final_ty.clone();
+                let loop_ty = self.current_breakable().unwrap().first_break_ty.clone();
 
                 self.exit_scope();
                 self.exit_breakable();
@@ -573,7 +575,7 @@ impl<'a> InferBody<'a> {
                 };
 
                 if let Some(breakable) = self.mut_current_breakable() {
-                    if let Some(break_ty) = breakable.final_ty.clone() {
+                    if let Some(break_ty) = breakable.first_break_ty.clone() {
                         // 2回目以降のbreakの型が最初に現れたbreakの型と異なる場合はエラーとする
                         self.unifier.unify(
                             &break_ty,

--- a/crates/hir_ty/src/inference.rs
+++ b/crates/hir_ty/src/inference.rs
@@ -538,7 +538,7 @@ impl<'a> InferBody<'a> {
                     &UnifyPurpose::MismatchedType {
                         expected_ty: Monotype::Unit,
                         found_ty: block_ty.clone(),
-                        found_expr: Some(*block),
+                        found_expr: *block,
                     },
                 );
 
@@ -570,7 +570,7 @@ impl<'a> InferBody<'a> {
                         &UnifyPurpose::MismatchedType {
                             expected_ty: break_ty.clone(),
                             found_ty: ty.clone(),
-                            found_expr: *value,
+                            found_expr: expr_id,
                         },
                     );
                 } else {

--- a/crates/hir_ty/src/inference/error.rs
+++ b/crates/hir_ty/src/inference/error.rs
@@ -137,7 +137,15 @@ pub enum InferenceError {
         found_expr: hir::ExprId,
     },
     BreakOutsideOfLoop {
+        /// break/continue種類
+        kind: BreakKind,
         /// 実際の式
         found_expr: hir::ExprId,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum BreakKind {
+    Continue,
+    Break,
 }

--- a/crates/hir_ty/src/inference/error.rs
+++ b/crates/hir_ty/src/inference/error.rs
@@ -136,4 +136,8 @@ pub enum InferenceError {
         /// 実際の式
         found_expr: hir::ExprId,
     },
+    BreakOutsideOfLoop {
+        /// 実際の式
+        found_expr: hir::ExprId,
+    },
 }

--- a/crates/hir_ty/src/inference/error.rs
+++ b/crates/hir_ty/src/inference/error.rs
@@ -134,6 +134,6 @@ pub enum InferenceError {
         /// 実際の型
         found_ty: Monotype,
         /// 実際の式
-        found_expr: Option<hir::ExprId>,
+        found_expr: hir::ExprId,
     },
 }

--- a/crates/hir_ty/src/inference/error.rs
+++ b/crates/hir_ty/src/inference/error.rs
@@ -127,4 +127,13 @@ pub enum InferenceError {
         /// 実際の式
         found_expr: hir::ExprId,
     },
+    /// 型が一致しない
+    MismatchedType {
+        /// 期待される型
+        expected_ty: Monotype,
+        /// 実際の型
+        found_ty: Monotype,
+        /// 実際の式
+        found_expr: Option<hir::ExprId>,
+    },
 }

--- a/crates/hir_ty/src/inference/type_unifier.rs
+++ b/crates/hir_ty/src/inference/type_unifier.rs
@@ -81,7 +81,7 @@ pub(crate) enum UnifyPurpose {
         /// 実際の型
         found_ty: Monotype,
         /// 実際の式
-        found_expr: Option<hir::ExprId>,
+        found_expr: hir::ExprId,
     },
 }
 

--- a/crates/hir_ty/src/inference/type_unifier.rs
+++ b/crates/hir_ty/src/inference/type_unifier.rs
@@ -75,6 +75,14 @@ pub(crate) enum UnifyPurpose {
         /// Noneの場合はブロック最後の式がないことを表します
         found_value: Option<hir::ExprId>,
     },
+    MismatchedType {
+        /// 期待する型
+        expected_ty: Monotype,
+        /// 実際の型
+        found_ty: Monotype,
+        /// 実際の式
+        found_expr: Option<hir::ExprId>,
+    },
 }
 
 /// 型の不一致を表すエラーを生成します。
@@ -160,6 +168,15 @@ fn build_unify_error_from_unify_purpose(
             found_last_expr: *found_value,
             expected_signature: *expected_signature,
             expected_function: *expected_function,
+        },
+        UnifyPurpose::MismatchedType {
+            expected_ty,
+            found_ty,
+            found_expr,
+        } => InferenceError::MismatchedType {
+            expected_ty: expected_ty.clone(),
+            found_ty: found_ty.clone(),
+            found_expr: *found_expr,
         },
     }
 }

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -2063,6 +2063,12 @@ mod tests {
                         }
 
                         break 20;
+
+                        fn f1() -> bool {
+                            loop {
+                                break true;
+                            }
+                        }
                     }
                 }
             "#,
@@ -2079,6 +2085,11 @@ mod tests {
                             break "bbb"; //: !
                         } //: string
                         break 20; //: !
+                        fn f1() -> bool {
+                            expr:loop {
+                                break true; //: !
+                            } //: bool
+                        }
                     } //: int
                 }
 

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -361,6 +361,12 @@ mod tests {
                                 self.debug_simplify_expr(hir_file, *found_expr),
                             ));
                         }
+                        InferenceError::BreakOutsideOfLoop { found_expr } => {
+                            msg.push_str(&format!(
+                                "error BreakOutsideOfLoop: found_expr: `{}`",
+                                self.debug_simplify_expr(hir_file, *found_expr),
+                            ));
+                        }
                     }
                     msg.push('\n');
                 }
@@ -2071,6 +2077,35 @@ mod tests {
                 }
 
                 ---
+                ---
+            "#]],
+        );
+    }
+
+    #[test]
+    fn break_outside_of_loop() {
+        check_in_root_file(
+            r#"
+                fn main() {
+                    loop {
+                    }
+
+                    break;
+                    break 10;
+                }
+            "#,
+            expect![[r#"
+                //- /main.nail
+                fn entry:main() -> () {
+                    loop {
+                    } //: !
+                    break; //: !
+                    break 10; //: !
+                }
+
+                ---
+                error BreakOutsideOfLoop: found_expr: `break`
+                error BreakOutsideOfLoop: found_expr: `break 10`
                 ---
             "#]],
         );

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -353,21 +353,13 @@ mod tests {
                             found_ty,
                             found_expr,
                         } => {
-                            if let Some(found_expr) = found_expr {
-                                msg.push_str(
+                            msg.push_str(
                                 &format!(
-                                    "error MismatchedType: expected_ty: {}, found_ty: {}, found_expr: `{}`",
-                                    self.debug_monotype(expected_ty),
-                                    self.debug_monotype(found_ty),
-                                    self.debug_simplify_expr(hir_file, *found_expr),
-                                ));
-                            } else {
-                                msg.push_str(&format!(
-                                    "error MismatchedType: expected_ty: {}, found_ty: {}",
-                                    self.debug_monotype(expected_ty),
-                                    self.debug_monotype(found_ty),
-                                ));
-                            }
+                                "error MismatchedType: expected_ty: {}, found_ty: {}, found_expr: `{}`",
+                                self.debug_monotype(expected_ty),
+                                self.debug_monotype(found_ty),
+                                self.debug_simplify_expr(hir_file, *found_expr),
+                            ));
                         }
                     }
                     msg.push('\n');
@@ -2033,8 +2025,8 @@ mod tests {
                 }
 
                 ---
-                error MismatchedType: expected_ty: int, found_ty: string, found_expr: `"aaa"`
-                error MismatchedType: expected_ty: int, found_ty: ()
+                error MismatchedType: expected_ty: int, found_ty: string, found_expr: `break "aaa"`
+                error MismatchedType: expected_ty: int, found_ty: (), found_expr: `break`
                 ---
             "#]],
         );

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -348,6 +348,27 @@ mod tests {
                                 found_module.name(self.db).text(self.db)
                             ));
                         }
+                        InferenceError::MismatchedType {
+                            expected_ty,
+                            found_ty,
+                            found_expr,
+                        } => {
+                            if let Some(found_expr) = found_expr {
+                                msg.push_str(
+                                &format!(
+                                    "error MismatchedType: expected_ty: {}, found_ty: {}, found_expr: `{}`",
+                                    self.debug_monotype(expected_ty),
+                                    self.debug_monotype(found_ty),
+                                    self.debug_simplify_expr(hir_file, *found_expr),
+                                ));
+                            } else {
+                                msg.push_str(&format!(
+                                    "error MismatchedType: expected_ty: {}, found_ty: {}",
+                                    self.debug_monotype(expected_ty),
+                                    self.debug_monotype(found_ty),
+                                ));
+                            }
+                        }
                     }
                     msg.push('\n');
                 }
@@ -675,8 +696,18 @@ mod tests {
 
                     msg
                 }
-                hir::Expr::Continue => todo!(),
-                hir::Expr::Break { .. } => todo!(),
+                hir::Expr::Continue => "continue".to_string(),
+                hir::Expr::Break { value } => {
+                    let mut msg = "break".to_string();
+                    if let Some(value) = value {
+                        msg.push_str(&format!(
+                            " {}",
+                            &self.debug_expr(hir_file, function, *value, nesting,)
+                        ));
+                    }
+
+                    msg
+                }
                 hir::Expr::Missing => "<missing>".to_string(),
             }
         }
@@ -770,8 +801,18 @@ mod tests {
 
                     msg
                 }
-                hir::Expr::Continue => todo!(),
-                hir::Expr::Break { .. } => todo!(),
+                hir::Expr::Continue => "continue".to_string(),
+                hir::Expr::Break { value } => {
+                    let mut msg = "break".to_string();
+                    if let Some(value) = value {
+                        msg.push_str(&format!(
+                            " {}",
+                            &self.debug_simplify_expr(hir_file, *value,)
+                        ));
+                    }
+
+                    msg
+                }
                 hir::Expr::Missing => "<missing>".to_string(),
             }
         }
@@ -1909,6 +1950,132 @@ mod tests {
                         10; //: int
                         20; //: int
                     } //: !
+                }
+
+                ---
+                ---
+            "#]],
+        );
+    }
+
+    #[test]
+    fn infer_break_no_expr() {
+        check_in_root_file(
+            r#"
+                fn main() {
+                    loop {
+                        break;
+                        break;
+                    }
+                }
+            "#,
+            expect![[r#"
+                //- /main.nail
+                fn entry:main() -> () {
+                    expr:loop {
+                        break; //: !
+                        break; //: !
+                    } //: ()
+                }
+
+                ---
+                ---
+            "#]],
+        );
+    }
+
+    #[test]
+    fn infer_break_expr() {
+        check_in_root_file(
+            r#"
+                fn main() -> int {
+                    loop {
+                        break 10;
+                        break 20;
+                    }
+                }
+            "#,
+            expect![[r#"
+                //- /main.nail
+                fn entry:main() -> int {
+                    expr:loop {
+                        break 10; //: !
+                        break 20; //: !
+                    } //: int
+                }
+
+                ---
+                ---
+            "#]],
+        );
+    }
+
+    #[test]
+    fn infer_break_expr_mismatched_type() {
+        check_in_root_file(
+            r#"
+                fn main() -> int {
+                    loop {
+                        break 10;
+                        break "aaa";
+                        break;
+                    }
+                }
+            "#,
+            expect![[r#"
+                //- /main.nail
+                fn entry:main() -> int {
+                    expr:loop {
+                        break 10; //: !
+                        break "aaa"; //: !
+                        break; //: !
+                    } //: int
+                }
+
+                ---
+                error MismatchedType: expected_ty: int, found_ty: string, found_expr: `"aaa"`
+                error MismatchedType: expected_ty: int, found_ty: ()
+                ---
+            "#]],
+        );
+    }
+
+    #[test]
+    fn infer_break_in_nested_loop() {
+        check_in_root_file(
+            r#"
+                fn main() -> int {
+                    loop {
+                        break 10;
+
+                        loop {
+                            break "aaa";
+
+                            loop {
+                                break;
+                            }
+
+                            break "bbb";
+                        }
+
+                        break 20;
+                    }
+                }
+            "#,
+            expect![[r#"
+                //- /main.nail
+                fn entry:main() -> int {
+                    expr:loop {
+                        break 10; //: !
+                        loop {
+                            break "aaa"; //: !
+                            loop {
+                                break; //: !
+                            } //: ()
+                            break "bbb"; //: !
+                        } //: string
+                        break 20; //: !
+                    } //: int
                 }
 
                 ---


### PR DESCRIPTION




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- 新機能: `break`と`continue`文のエラーハンドリングを強化しました。これにより、コードの型不一致やループ外での`break`と`continue`の使用に対するエラーメッセージが改善されます。
- 新機能: ネストしたループのコンテキストを管理するための新しい構造体`BreakableContext`を導入しました。これにより、ループ内の`break`文の型を追跡し、エラーチェックを行うことが可能になります。
- テスト: 新たに追加された機能に対するテストケースを追加しました。これにより、新機能の信頼性が向上します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->