### PR TITLE
Impl assign binary operator AST

### DIFF
--- a/crates/ast/src/tokens/operators.rs
+++ b/crates/ast/src/tokens/operators.rs
@@ -12,6 +12,7 @@ pub enum BinaryOp {
     Equal(Eq2),
     GreaterThan(RAngle),
     LessThan(LAngle),
+    Assign(Eq),
 }
 def_ast_token!(Plus);
 def_ast_token!(Minus);
@@ -20,6 +21,7 @@ def_ast_token!(Slash);
 def_ast_token!(Eq2);
 def_ast_token!(LAngle);
 def_ast_token!(RAngle);
+def_ast_token!(Eq);
 
 impl Ast for BinaryOp {}
 impl AstToken for BinaryOp {
@@ -33,6 +35,7 @@ impl AstToken for BinaryOp {
                 | SyntaxKind::Eq2
                 | SyntaxKind::LAngle
                 | SyntaxKind::RAngle
+                | SyntaxKind::Eq
         )
     }
 
@@ -45,6 +48,7 @@ impl AstToken for BinaryOp {
             SyntaxKind::Eq2 => Some(Self::Equal(Eq2 { syntax })),
             SyntaxKind::LAngle => Some(Self::LessThan(LAngle { syntax })),
             SyntaxKind::RAngle => Some(Self::GreaterThan(RAngle { syntax })),
+            SyntaxKind::Eq => Some(Self::Assign(Eq { syntax })),
             _ => None,
         }
     }
@@ -58,6 +62,7 @@ impl AstToken for BinaryOp {
             Self::Equal(it) => it.syntax(),
             Self::GreaterThan(it) => it.syntax(),
             Self::LessThan(it) => it.syntax(),
+            Self::Assign(it) => it.syntax(),
         }
     }
 }

--- a/crates/dock/src/lib.rs
+++ b/crates/dock/src/lib.rs
@@ -327,7 +327,8 @@ impl Diagnostic {
                     ast::BinaryOp::Div(_) => "/",
                     ast::BinaryOp::Equal(_)
                     | ast::BinaryOp::GreaterThan(_)
-                    | ast::BinaryOp::LessThan(_) => unreachable!(),
+                    | ast::BinaryOp::LessThan(_)
+                    | ast::BinaryOp::Assign(_) => unreachable!(),
                 };
 
                 Diagnostic {
@@ -359,7 +360,8 @@ impl Diagnostic {
                     ast::BinaryOp::Add(_)
                     | ast::BinaryOp::Sub(_)
                     | ast::BinaryOp::Mul(_)
-                    | ast::BinaryOp::Div(_) => unreachable!(),
+                    | ast::BinaryOp::Div(_)
+                    | ast::BinaryOp::Assign(_) => unreachable!(),
                 };
 
                 Diagnostic {

--- a/crates/hir/src/body.rs
+++ b/crates/hir/src/body.rs
@@ -841,6 +841,7 @@ mod tests {
                     ast::BinaryOp::Equal(_) => "==",
                     ast::BinaryOp::GreaterThan(_) => ">",
                     ast::BinaryOp::LessThan(_) => "<",
+                    ast::BinaryOp::Assign(_) => "=",
                 };
                 let lhs_str = debug_expr(db, hir_file, resolution_map, scope_origin, *lhs, nesting);
                 let rhs_str = debug_expr(db, hir_file, resolution_map, scope_origin, *rhs, nesting);

--- a/crates/hir_ty/src/inference.rs
+++ b/crates/hir_ty/src/inference.rs
@@ -393,6 +393,7 @@ impl<'a> InferBody<'a> {
 
                     Monotype::Bool
                 }
+                ast::BinaryOp::Assign(_) => unimplemented!(),
             },
             hir::Expr::Unary { op, expr } => match op {
                 ast::UnaryOp::Neg(_) => {

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -626,6 +626,7 @@ mod tests {
                         ast::BinaryOp::Equal(_) => "==",
                         ast::BinaryOp::GreaterThan(_) => ">",
                         ast::BinaryOp::LessThan(_) => "<",
+                        ast::BinaryOp::Assign(_) => "=",
                     };
                     let lhs_str = self.debug_expr(hir_file, function, *lhs, nesting);
                     let rhs_str = self.debug_expr(hir_file, function, *rhs, nesting);
@@ -734,6 +735,7 @@ mod tests {
                         ast::BinaryOp::Equal(_) => "==",
                         ast::BinaryOp::GreaterThan(_) => ">",
                         ast::BinaryOp::LessThan(_) => "<",
+                        ast::BinaryOp::Assign(_) => "=",
                     };
                     let lhs_str = self.debug_simplify_expr(hir_file, *lhs);
                     let rhs_str = self.debug_simplify_expr(hir_file, *rhs);
@@ -844,6 +846,7 @@ mod tests {
                 ast::BinaryOp::Equal(_) => "==",
                 ast::BinaryOp::GreaterThan(_) => ">",
                 ast::BinaryOp::LessThan(_) => "<",
+                ast::BinaryOp::Assign(_) => "=",
             }
             .to_string()
         }

--- a/crates/mir/src/body.rs
+++ b/crates/mir/src/body.rs
@@ -412,6 +412,7 @@ impl<'a> FunctionLower<'a> {
                     ast::BinaryOp::Equal(_) => BinaryOp::Equal,
                     ast::BinaryOp::GreaterThan(_) => BinaryOp::GreaterThan,
                     ast::BinaryOp::LessThan(_) => BinaryOp::LessThan,
+                    ast::BinaryOp::Assign(_) => unimplemented!(),
                 };
 
                 let local = self.alloc_local(expr_id);

--- a/crates/parser/src/grammar/expr.rs
+++ b/crates/parser/src/grammar/expr.rs
@@ -890,7 +890,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_binary_expression_assign_right() {
+    fn parse_binary_expression_assign_right_to_left() {
         check_debug_tree_in_block(
             "a = b = 20",
             expect![[r#"

--- a/crates/parser/src/grammar/expr.rs
+++ b/crates/parser/src/grammar/expr.rs
@@ -68,6 +68,8 @@ fn parse_expr_binding_power(
             BinaryOp::LessThan
         } else if parser.at(TokenKind::RAngle) {
             BinaryOp::GreaterThan
+        } else if parser.at(TokenKind::Eq) {
+            BinaryOp::Assign
         } else {
             break;
         };
@@ -108,6 +110,8 @@ enum BinaryOp {
     GreaterThan,
     /// `<`
     LessThan,
+    /// `=`
+    Assign,
 }
 
 impl BinaryOp {
@@ -116,10 +120,11 @@ impl BinaryOp {
     /// 結合力が強いほど値が大きくなります。
     fn binding_power(&self) -> (u8, u8) {
         match self {
-            Self::Equal => (1, 2),
-            Self::GreaterThan | Self::LessThan => (3, 4),
-            Self::Add | Self::Sub => (5, 6),
-            Self::Mul | Self::Div => (7, 8),
+            Self::Assign => (2, 1),
+            Self::Equal => (3, 4),
+            Self::GreaterThan | Self::LessThan => (5, 6),
+            Self::Add | Self::Sub => (7, 8),
+            Self::Mul | Self::Div => (9, 10),
         }
     }
 }
@@ -864,6 +869,56 @@ mod tests {
     }
 
     #[test]
+    fn parse_binary_expression_assign() {
+        check_debug_tree_in_block(
+            "a = 10",
+            expect![[r#"
+                SourceFile@0..6
+                  ExprStmt@0..6
+                    BinaryExpr@0..6
+                      PathExpr@0..1
+                        Path@0..1
+                          PathSegment@0..1
+                            Ident@0..1 "a"
+                      Whitespace@1..2 " "
+                      Eq@2..3 "="
+                      Whitespace@3..4 " "
+                      Literal@4..6
+                        Integer@4..6 "10"
+            "#]],
+        );
+    }
+
+    #[test]
+    fn parse_binary_expression_assign_right() {
+        check_debug_tree_in_block(
+            "a = b = 20",
+            expect![[r#"
+                SourceFile@0..10
+                  ExprStmt@0..10
+                    BinaryExpr@0..10
+                      PathExpr@0..1
+                        Path@0..1
+                          PathSegment@0..1
+                            Ident@0..1 "a"
+                      Whitespace@1..2 " "
+                      Eq@2..3 "="
+                      Whitespace@3..4 " "
+                      BinaryExpr@4..10
+                        PathExpr@4..5
+                          Path@4..5
+                            PathSegment@4..5
+                              Ident@4..5 "b"
+                        Whitespace@5..6 " "
+                        Eq@6..7 "="
+                        Whitespace@7..8 " "
+                        Literal@8..10
+                          Integer@8..10 "20"
+            "#]],
+        );
+    }
+
+    #[test]
     fn parse_call_in_binary() {
         check_debug_tree_in_block(
             "foo(1) + bar(2)",
@@ -913,7 +968,7 @@ mod tests {
                         Path@1..4
                           PathSegment@1..4
                             Ident@1..4 "foo"
-                error at 1..4: expected '::', '+', '-', '*', '/', '==', '<', '>' or ')'
+                error at 1..4: expected '::', '+', '-', '*', '/', '==', '<', '>', '=' or ')'
             "#]],
         );
     }
@@ -970,7 +1025,7 @@ mod tests {
                         Literal@2..3
                           Integer@2..3 "1"
                   Whitespace@3..4 " "
-                error at 3..4: expected '+', '-', '*', '/', '==', '<', '>', ';' or '}'
+                error at 3..4: expected '+', '-', '*', '/', '==', '<', '>', '=', ';' or '}'
             "#]],
         );
     }
@@ -1148,7 +1203,7 @@ mod tests {
                             Path@5..6
                               PathSegment@5..6
                                 Ident@5..6 "y"
-                error at 5..6: expected '::', '+', '-', '*', '/', '==', '<', '>', ',' or ')'
+                error at 5..6: expected '::', '+', '-', '*', '/', '==', '<', '>', '=', ',' or ')'
             "#]],
         );
 
@@ -1191,7 +1246,7 @@ mod tests {
                             Path@2..3
                               PathSegment@2..3
                                 Ident@2..3 "x"
-                error at 2..3: expected '::', '+', '-', '*', '/', '==', '<', '>', ',' or ')'
+                error at 2..3: expected '::', '+', '-', '*', '/', '==', '<', '>', '=', ',' or ')'
             "#]],
         );
 
@@ -1262,8 +1317,8 @@ mod tests {
                   ExprStmt@5..6
                     Error@5..6
                       RParen@5..6 ")"
-                error at 4..5: expected '::', '+', '-', '*', '/', '==', '<', '>', ',' or ')', but found identifier
-                error at 5..6: expected '+', '-', '*', '/', '==', '<', '>', ';', 'let', 'fn', 'mod', integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '!', '(', '{', 'if', 'return', 'loop', 'continue', 'break' or 'while', but found ')'
+                error at 4..5: expected '::', '+', '-', '*', '/', '==', '<', '>', '=', ',' or ')', but found identifier
+                error at 5..6: expected '+', '-', '*', '/', '==', '<', '>', '=', ';', 'let', 'fn', 'mod', integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '!', '(', '{', 'if', 'return', 'loop', 'continue', 'break' or 'while', but found ')'
             "#]],
         );
     }


### PR DESCRIPTION




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- 新機能：代入演算子（`=`）のサポートを追加しました。これにより、ユーザーはより複雑な式を作成し、プログラムの動作をより詳細に制御できるようになります。
- テスト：代入演算子のパースをテストする新しいテストケースを追加しました。これにより、新機能の信頼性と安定性が向上します。
- ドキュメンテーション：デバッグ出力で代入演算子を正しく扱うためのサポートを追加しました。これにより、開発者はデバッグプロセスをより効率的に行うことができます。

注意：一部のコードでは、代入演算子の処理ロジックがまだ実装されていないため、これらの部分は現在未実装とマークされています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->