### PR TITLE
Impl assign binary op MIR

### DIFF
--- a/crates/mir/src/body.rs
+++ b/crates/mir/src/body.rs
@@ -392,13 +392,13 @@ impl<'a> FunctionLower<'a> {
                 }
             }
             hir::Expr::Binary { op, lhs, rhs } => {
-                let lhs = match self.lower_expr(*lhs) {
+                let lhs_operand = match self.lower_expr(*lhs) {
                     LoweredExpr::Return => return LoweredExpr::Return,
                     LoweredExpr::Break => return LoweredExpr::Break,
                     LoweredExpr::Operand(operand) => operand,
                 };
 
-                let rhs = match self.lower_expr(*rhs) {
+                let rhs_oeprand = match self.lower_expr(*rhs) {
                     LoweredExpr::Return => return LoweredExpr::Return,
                     LoweredExpr::Break => return LoweredExpr::Break,
                     LoweredExpr::Operand(operand) => operand,
@@ -412,14 +412,20 @@ impl<'a> FunctionLower<'a> {
                     ast::BinaryOp::Equal(_) => BinaryOp::Equal,
                     ast::BinaryOp::GreaterThan(_) => BinaryOp::GreaterThan,
                     ast::BinaryOp::LessThan(_) => BinaryOp::LessThan,
-                    ast::BinaryOp::Assign(_) => unimplemented!(),
+                    ast::BinaryOp::Assign(_) => {
+                        let local = self.alloc_local(*lhs);
+                        let value = Value::Operand(rhs_oeprand);
+                        let place = Place::Local(local);
+                        self.add_statement_to_current_bb(Statement::Assign { place, value });
+                        return LoweredExpr::Operand(Operand::Constant(Constant::Unit));
+                    }
                 };
 
                 let local = self.alloc_local(expr_id);
                 let value = Value::BinaryOp {
                     op,
-                    left: lhs,
-                    right: rhs,
+                    left: lhs_operand,
+                    right: rhs_oeprand,
                 };
                 let place = Place::Local(local);
                 self.add_statement_to_current_bb(Statement::Assign { place, value });

--- a/crates/mir/src/body.rs
+++ b/crates/mir/src/body.rs
@@ -398,7 +398,7 @@ impl<'a> FunctionLower<'a> {
                     LoweredExpr::Operand(operand) => operand,
                 };
 
-                let rhs_oeprand = match self.lower_expr(*rhs) {
+                let rhs_operand = match self.lower_expr(*rhs) {
                     LoweredExpr::Return => return LoweredExpr::Return,
                     LoweredExpr::Break => return LoweredExpr::Break,
                     LoweredExpr::Operand(operand) => operand,
@@ -414,7 +414,7 @@ impl<'a> FunctionLower<'a> {
                     ast::BinaryOp::LessThan(_) => BinaryOp::LessThan,
                     ast::BinaryOp::Assign(_) => {
                         let local = self.alloc_local(*lhs);
-                        let value = Value::Operand(rhs_oeprand);
+                        let value = Value::Operand(rhs_operand);
                         let place = Place::Local(local);
                         self.add_statement_to_current_bb(Statement::Assign { place, value });
                         return LoweredExpr::Operand(Operand::Constant(Constant::Unit));
@@ -425,7 +425,7 @@ impl<'a> FunctionLower<'a> {
                 let value = Value::BinaryOp {
                     op,
                     left: lhs_operand,
-                    right: rhs_oeprand,
+                    right: rhs_operand,
                 };
                 let place = Place::Local(local);
                 self.add_statement_to_current_bb(Statement::Assign { place, value });

--- a/crates/mir/src/lib.rs
+++ b/crates/mir/src/lib.rs
@@ -977,6 +977,66 @@ mod tests {
     }
 
     #[test]
+    fn test_assign() {
+        check_in_root_file(
+            r#"
+                fn main() {
+                    let a = 1;
+                    a = 10;
+                }
+            "#,
+            expect![[r#"
+                fn t_pod::main() -> () {
+                    let _0: ()
+                    let _1: int
+                    let _2: int
+
+                    entry: {
+                        _1 = const 1
+                        _2 = const 10
+                        goto -> exit
+                    }
+
+                    exit: {
+                        return _0
+                    }
+                }
+            "#]],
+        );
+    }
+
+    #[test]
+    fn test_assign_returns_unit() {
+        check_in_root_file(
+            r#"
+                fn main() {
+                    let a = 1;
+                    let b = a = 10;
+                }
+            "#,
+            expect![[r#"
+                fn t_pod::main() -> () {
+                    let _0: ()
+                    let _1: int
+                    let _2: ()
+                    let _3: int
+
+                    entry: {
+                        _1 = const 1
+                        _3 = const 10
+                        _2 = const ()
+                        goto -> exit
+                    }
+
+                    exit: {
+                        return _0
+                    }
+                }
+            "#]],
+        );
+    }
+
+    #[test]
     fn test_negative_number() {
         check_in_root_file(
             r#"


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- リファクタリング: `FunctionLower`の実装における変数名を`lhs`から`lhs_operand`、`rhs`から`rhs_operand`に変更しました。これにより、コードの可読性が向上し、理解しやすくなりました。
- 新機能: `ast::BinaryOp::Assign`ケースの取り扱いを改善しました。右側のオペランドをローカル変数に割り当て、`LoweredExpr::Operand(Operand::Constant(Constant::Unit))`を返すようになりました。これにより、代入操作の取り扱いがより直感的になりました。
- テスト: 代入のテストケースを2つ追加しました。これにより、代入の期待される動作をより正確に確認できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->