### PR TITLE
Impl assign binary op codegen

### DIFF
--- a/crates/codegen_llvm/src/lib.rs
+++ b/crates/codegen_llvm/src/lib.rs
@@ -1449,6 +1449,26 @@ mod tests {
     }
 
     #[test]
+    fn test_assign() {
+        check_result_in_root_file(
+            r#"
+                fn main() -> int {
+                    let a = 10;
+                    a = 20;
+
+                    a
+                }
+            "#,
+            expect![[r#"
+                {
+                  "nail_type": "Int",
+                  "value": 20
+                }
+            "#]],
+        );
+    }
+
+    #[test]
     fn test_negative_number() {
         check_result_in_root_file(
             r#"

--- a/crates/codegen_llvm/src/lib.rs
+++ b/crates/codegen_llvm/src/lib.rs
@@ -1763,31 +1763,30 @@ mod tests {
         );
     }
 
-    // TODO: 代入(=)を実装して、動作するようにする
-    // #[test]
-    // fn test_loop_continue() {
-    //     check_result_in_root_file(
-    //         r#"
-    //             fn main() -> int {
-    //                 let i = 0;
-    //                 loop {
-    //                     if i == 0 {
-    //                         i = i + 1;
-    //                         continue;
-    //                     } else {
-    //                         break i;
-    //                     }
-    //                 }
-    //             }
-    //         "#,
-    //         expect![[r#"
-    //             {
-    //               "nail_type": "Int",
-    //               "value": 1
-    //             }
-    //         "#]],
-    //     );
-    // }
+    #[test]
+    fn test_loop_continue() {
+        check_result_in_root_file(
+            r#"
+                fn main() -> int {
+                    let i = 0;
+                    loop {
+                        if i == 0 {
+                            i = i + 1;
+                            continue;
+                        } else {
+                            break i;
+                        }
+                    }
+                }
+            "#,
+            expect![[r#"
+                {
+                  "nail_type": "Int",
+                  "value": 1
+                }
+            "#]],
+        );
+    }
 
     #[test]
     fn test_modules() {

--- a/crates/dock/tests/type_check.rs
+++ b/crates/dock/tests/type_check.rs
@@ -158,6 +158,16 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn binary_assign_match() {
+        check("binary_assign_match").await;
+    }
+
+    #[tokio::test]
+    async fn binary_assign_mismatch() {
+        check("binary_assign_mismatch").await;
+    }
+
+    #[tokio::test]
     async fn unary_match() {
         check("unary_match").await;
     }

--- a/crates/dock/tests/type_check/binary_assign_match/main.nail
+++ b/crates/dock/tests/type_check/binary_assign_match/main.nail
@@ -1,0 +1,15 @@
+fn main() -> int {
+  let a = 10;
+  a = 20;
+
+  a
+}
+
+//---stdout
+
+// {
+//   "nail_type": "Int",
+//   "value": 20
+// }
+
+//---stderr

--- a/crates/dock/tests/type_check/binary_assign_mismatch/main.nail
+++ b/crates/dock/tests/type_check/binary_assign_mismatch/main.nail
@@ -1,0 +1,19 @@
+fn main() -> int {
+  let a = 10;
+  a = "aaa";
+
+  a
+}
+
+//---stdout
+//---stderr
+
+// Error: Mismatched type
+//    ╭─[/{nail}/crates/dock/tests/type_check/binary_assign_mismatch/main.nail:3:3]
+//    │
+//  3 │   a = "aaa";
+//    │   ┬   ──┬──  
+//    │   ╰────────── Type is int
+//    │         │    
+//    │         ╰──── Type is string
+// ───╯

--- a/crates/mir/src/body.rs
+++ b/crates/mir/src/body.rs
@@ -413,9 +413,11 @@ impl<'a> FunctionLower<'a> {
                     ast::BinaryOp::GreaterThan(_) => BinaryOp::GreaterThan,
                     ast::BinaryOp::LessThan(_) => BinaryOp::LessThan,
                     ast::BinaryOp::Assign(_) => {
-                        let local = self.alloc_local(*lhs);
+                        let place = match lhs_operand {
+                            Operand::Place(place) => place,
+                            Operand::Constant(_) => unreachable!(),
+                        };
                         let value = Value::Operand(rhs_operand);
-                        let place = Place::Local(local);
                         self.add_statement_to_current_bb(Statement::Assign { place, value });
                         return LoweredExpr::Operand(Operand::Constant(Constant::Unit));
                     }

--- a/crates/mir/src/lib.rs
+++ b/crates/mir/src/lib.rs
@@ -989,11 +989,41 @@ mod tests {
                 fn t_pod::main() -> () {
                     let _0: ()
                     let _1: int
-                    let _2: int
 
                     entry: {
                         _1 = const 1
-                        _2 = const 10
+                        _1 = const 10
+                        goto -> exit
+                    }
+
+                    exit: {
+                        return _0
+                    }
+                }
+            "#]],
+        );
+    }
+
+    #[test]
+    fn test_return_assigned() {
+        check_in_root_file(
+            r#"
+                fn main() -> int {
+                    let a = 10;
+                    a = 20;
+
+                    a
+                }
+            "#,
+            expect![[r#"
+                fn t_pod::main() -> int {
+                    let _0: int
+                    let _1: int
+
+                    entry: {
+                        _1 = const 10
+                        _1 = const 20
+                        _0 = _1
                         goto -> exit
                     }
 
@@ -1019,11 +1049,10 @@ mod tests {
                     let _0: ()
                     let _1: int
                     let _2: ()
-                    let _3: int
 
                     entry: {
                         _1 = const 1
-                        _3 = const 10
+                        _1 = const 10
                         _2 = const ()
                         goto -> exit
                     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- 新機能：代入演算子(`=`)と`loop`ステートメントの`continue`と`break`に対する新しいテストケースが追加されました。これにより、これらの操作の挙動が正しく検証されます。
- リファクタ：`FunctionLower`の実装が改善され、コードが簡素化されました。これにより、ローカル変数の代わりに`lhs_operand`をマッチングして`place`を決定し、`rhs_operand`をその`place`に割り当てるようになりました。
- テスト：`binary_assign_match`と`binary_assign_mismatch`という新しいテスト関数が追加され、さまざまな入力パラメータで`check`関数を呼び出します。これにより、より広範なテストが可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->