### PR TITLE
Switch docker hub to GHCR

### DIFF
--- a/.github/workflows/nail.yml
+++ b/.github/workflows/nail.yml
@@ -18,11 +18,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform: [linux/amd64, linux/arm64]
-      fail-fast: false
-
     container:
       image: ghcr.io/ktanaka101/nail/nail-builder:latest
 

--- a/.github/workflows/nail.yml
+++ b/.github/workflows/nail.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: docker.io/ktanaka101/nail-builder:latest
+      image: ghcr.io/ktanaka101/nail/nail-builder:latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- ワークフロー設定で使用するDockerイメージの参照を更新しました。
	- Dockerイメージの参照を `docker.io/ktanaka101/nail-builder:latest` から `ghcr.io/ktanaka101/nail/nail-builder:latest` に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->