### PR TITLE
Improve Documentation Comments for `ExprId` in `body.rs

### DIFF
--- a/crates/hir/src/body.rs
+++ b/crates/hir/src/body.rs
@@ -12,11 +12,11 @@ use crate::{
     UseItem,
 };
 
-/// 式を一意に識別するためのID
+/// Represents a unique ID for an expression in HIR
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ExprId(Idx<Expr>);
 impl ExprId {
-    /// このIDに対応する式を取得する
+    /// Retrieves the expression associated with this ID, given a context
     pub fn lookup(self, ctx: &HirFileDatabase) -> &Expr {
         &ctx.exprs[self.0]
     }


### PR DESCRIPTION
## **Type**
documentation


___

## **Description**
- Updated the documentation comments in `body.rs` to improve clarity and descriptiveness.
- The `ExprId` struct and its method `lookup` now have more detailed comments explaining their purpose and usage.



___



___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

