### PR TITLE
Implement support for mutability with `mut` keyword across compiler components and update documentation

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -92,6 +92,13 @@ args = [
 ]
 install_crate = false
 
+[tasks.nail_test_update]
+private = true
+command = "cargo"
+args = ["nextest", "run", "--workspace"]
+install_crate = false
+env = { "UPDATE_EXPECT" = "1" }
+
 
 [tasks.nail_check]
 private = true

--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ impl Custom {
   }
 
   fn copy_self(*self) -> *Custom {
-    *self.copy()
+    *self.copy() // Error
   }
 
   /** NotCopyable */
@@ -593,6 +593,77 @@ trait Copy: Clone {
 // Essentially, only primitive types implement this.
 // note: On the IDE, want to change the color
 trait AutoCopy: Copy {
+}
+```
+
+- Reference / Copy semantics
+Consider that it is always a copy of the reference.
+
+```rust
+struct NotCopyable(i32);
+
+struct Copyable(i32);
+impl Copy for Copyable {}
+
+struct Custom {
+  not_copyable: NotCopyable
+  copyable: Copyable
+  auto_copyable: i32
+}
+impl Custom {
+  fn new() -> *Custom {
+    *Custom { a: 10 }
+  }
+
+  /** Custom */
+  fn ref_self(self) -> Custom {
+    self
+  }
+
+  fn copy_self(self) -> Custom {
+    self.copy() // Error
+  }
+
+  /** NotCopyable */
+  fn ref_not_copyable(self) -> NotCopyable {
+    self.not_copyable
+  }
+
+  fn copy_not_copyable(self) -> NotCopyable {
+    self.not_copyable.copy() // Error
+  }
+
+  /** Copyable */
+  fn ref_copyable(self) -> Copyable {
+    self.copyable
+  }
+
+  fn copy_copyable(self) -> Copyable {
+    self.copyable.copy() // or *self.copyable
+  }
+
+  /** AutoCopyable */
+  fn ref_auto_copyable(self) -> i32 {
+    self.auto_copyable // Auto copy, no reference
+  }
+
+  fn copy_auto_copyable(self) -> i32 {
+    self.auto_copyable // or self.auto_copyable.copy() or *self.auto_copyable
+  }
+}
+```
+
+It can also consume itself or its arguments.
+
+```rust
+impl Custom {
+  fn consume_self(consume self) {
+    // After that, self cannot be accessed.
+  }
+
+  fn consume_arg(self, x: consume i32) {
+    // The x passed to this function will be consumed.
+  }
 }
 ```
 

--- a/collect-codes.sh
+++ b/collect-codes.sh
@@ -1,4 +1,4 @@
-#!bin/sh
+#!/bin/sh
 
 cargo binstall tokei && \
 tokei ./ \

--- a/collect-codes.sh
+++ b/collect-codes.sh
@@ -1,0 +1,13 @@
+#!bin/sh
+
+cargo binstall tokei && \
+tokei ./ \
+  -e .git \
+  -e Cargo.lock \
+  -e target \
+  -e yarn.lock \
+  -e .vscode-test \
+  -e node_modules \
+  -e out \
+  -e fuzz/artifacts \
+  -e fuzz/corpus

--- a/crates/ast/src/ast_node.rs
+++ b/crates/ast/src/ast_node.rs
@@ -80,6 +80,7 @@ pub fn children_nodes<TNode: AstNode, TChildNode: AstNode>(
     node.syntax().children().filter_map(TChildNode::cast)
 }
 
+/// 指定したノードから指定した`kind`のトークンを探して最初の一つ目を返します。
 pub fn token(parent: &SyntaxNode, kind: SyntaxKind) -> Option<SyntaxToken> {
     parent
         .children_with_tokens()

--- a/crates/ast/src/ast_node.rs
+++ b/crates/ast/src/ast_node.rs
@@ -80,6 +80,13 @@ pub fn children_nodes<TNode: AstNode, TChildNode: AstNode>(
     node.syntax().children().filter_map(TChildNode::cast)
 }
 
+pub fn token(parent: &SyntaxNode, kind: SyntaxKind) -> Option<SyntaxToken> {
+    parent
+        .children_with_tokens()
+        .filter_map(|it| it.into_token())
+        .find(|it| it.kind() == kind)
+}
+
 /// 指定したノードから型引数<TChildToken>を子トークンから探して最初の一つ目を返します。
 pub fn child_token<TNode: AstNode, TChildToken: AstToken>(node: &TNode) -> Option<TChildToken> {
     node.syntax()

--- a/crates/ast/src/ast_node.rs
+++ b/crates/ast/src/ast_node.rs
@@ -1,5 +1,5 @@
 use rowan::TextRange;
-use syntax::{SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken};
+use syntax::{SyntaxKind, SyntaxNode, SyntaxToken};
 
 /// ASTノード
 pub trait Ast {}
@@ -84,16 +84,20 @@ pub fn children_nodes<TNode: AstNode, TChildNode: AstNode>(
 pub fn token(parent: &SyntaxNode, kind: SyntaxKind) -> Option<SyntaxToken> {
     parent
         .children_with_tokens()
-        .filter_map(|it| it.into_token())
-        .find(|it| it.kind() == kind)
+        .find_map(|it| match it.into_token() {
+            Some(token) if token.kind() == kind => Some(token),
+            _ => None,
+        })
 }
 
 /// 指定したノードから型引数<TChildToken>を子トークンから探して最初の一つ目を返します。
 pub fn child_token<TNode: AstNode, TChildToken: AstToken>(node: &TNode) -> Option<TChildToken> {
     node.syntax()
         .children_with_tokens()
-        .filter_map(SyntaxElement::into_token)
-        .find_map(TChildToken::cast)
+        .find_map(|it| match it.into_token() {
+            Some(token) => TChildToken::cast(token),
+            None => None,
+        })
 }
 
 /// 指定したノードから型引数<TChildToken>を子トークンから探して全て返します。
@@ -102,6 +106,8 @@ pub fn children_tokens<TNode: AstNode, TChildToken: AstToken>(
 ) -> impl Iterator<Item = TChildToken> {
     node.syntax()
         .children_with_tokens()
-        .filter_map(SyntaxElement::into_token)
-        .filter_map(TChildToken::cast)
+        .filter_map(|it| match it.into_token() {
+            Some(token) => TChildToken::cast(token),
+            None => None,
+        })
 }

--- a/crates/ast/src/nodes.rs
+++ b/crates/ast/src/nodes.rs
@@ -70,6 +70,7 @@ def_ast_node!(
     VariableDef
 );
 impl VariableDef {
+    /// 変数の可変定義に位置する`mut`トークンを返します。
     pub fn mut_token(&self) -> Option<SyntaxToken> {
         ast_node::token(&self.syntax, SyntaxKind::MutKw)
     }
@@ -526,6 +527,7 @@ impl Param {
         ast_node::child_token(self)
     }
 
+    /// `mut`キーワードに位置するトークンを返します。
     pub fn mut_token(&self) -> Option<SyntaxToken> {
         ast_node::token(self.syntax(), SyntaxKind::MutKw)
     }

--- a/crates/ast/src/nodes.rs
+++ b/crates/ast/src/nodes.rs
@@ -70,6 +70,10 @@ def_ast_node!(
     VariableDef
 );
 impl VariableDef {
+    pub fn mut_token(&self) -> Option<SyntaxToken> {
+        ast_node::token(&self.syntax, SyntaxKind::MutKw)
+    }
+
     /// 変数の名前に位置するASTトークンを返します。
     pub fn name(&self) -> Option<tokens::Ident> {
         ast_node::child_token(self)

--- a/crates/ast/src/nodes.rs
+++ b/crates/ast/src/nodes.rs
@@ -526,6 +526,10 @@ impl Param {
         ast_node::child_token(self)
     }
 
+    pub fn mut_token(&self) -> Option<SyntaxToken> {
+        ast_node::token(self.syntax(), SyntaxKind::MutKw)
+    }
+
     /// パラメータの型に位置する型ノードを返します。
     pub fn ty(&self) -> Option<Type> {
         ast_node::child_node(self)

--- a/crates/hir/src/body.rs
+++ b/crates/hir/src/body.rs
@@ -825,21 +825,7 @@ mod tests {
             .iter()
             .map(|param| {
                 let param_data = param.data(hir_file.db(db));
-                let name = if let Some(name) = param_data.name {
-                    name.text(db)
-                } else {
-                    "<missing>"
-                };
-                let mutable_text = if param_data.mutability { "mut " } else { "" };
-                let ty = match param_data.ty {
-                    Type::Integer => "int",
-                    Type::String => "string",
-                    Type::Char => "char",
-                    Type::Boolean => "bool",
-                    Type::Unit => "()",
-                    Type::Unknown => "<unknown>",
-                };
-                format!("{name}: {mutable_text}{ty}")
+                crate::testing::format_parameter(db, param_data)
             })
             .collect::<Vec<_>>()
             .join(", ");

--- a/crates/hir/src/body.rs
+++ b/crates/hir/src/body.rs
@@ -368,7 +368,7 @@ impl<'a> BodyLower<'a> {
                 self.scopes.define(name, expr);
                 Stmt::VariableDef {
                     name,
-                    is_mutability: def.mut_token().is_some(),
+                    mutable: def.mut_token().is_some(),
                     value: expr,
                 }
             }
@@ -946,18 +946,14 @@ mod tests {
         match stmt {
             Stmt::VariableDef {
                 name,
-                is_mutability,
+                mutable,
                 value,
             } => {
                 let name = name.text(db);
                 let expr_str =
                     debug_expr(db, hir_file, resolution_map, scope_origin, *value, nesting);
-                let mutability = if *is_mutability {
-                    "mut ".to_string()
-                } else {
-                    "".to_string()
-                };
-                format!("{}let {mutability}{name} = {expr_str}\n", indent(nesting))
+                let mutable_text = crate::testing::format_mutable(*mutable);
+                format!("{}let {mutable_text}{name} = {expr_str}\n", indent(nesting))
             }
             Stmt::ExprStmt {
                 expr,

--- a/crates/hir/src/item.rs
+++ b/crates/hir/src/item.rs
@@ -14,13 +14,13 @@ impl Param {
         name: Option<Name>,
         ty: Type,
         pos: usize,
-        mutability: bool,
+        mutable: bool,
     ) -> Self {
         hir_file_ctx.alloc_param(ParamData {
             name,
             ty,
             pos,
-            mutability,
+            mutable,
         })
     }
 
@@ -44,7 +44,7 @@ pub struct ParamData {
     /// 例: `fn f(x: int, y: int)` であれば `x` は `0` で `y` は `1`
     pub pos: usize,
     /// パラメータの可変性
-    pub mutability: bool,
+    pub mutable: bool,
 }
 
 /// 型を表す

--- a/crates/hir/src/item.rs
+++ b/crates/hir/src/item.rs
@@ -14,8 +14,14 @@ impl Param {
         name: Option<Name>,
         ty: Type,
         pos: usize,
+        mutability: bool,
     ) -> Self {
-        hir_file_ctx.alloc_param(ParamData { name, ty, pos })
+        hir_file_ctx.alloc_param(ParamData {
+            name,
+            ty,
+            pos,
+            mutability,
+        })
     }
 
     /// パラメータのデータを取得します。
@@ -37,6 +43,8 @@ pub struct ParamData {
     /// パラメータの位置(0-indexed)
     /// 例: `fn f(x: int, y: int)` であれば `x` は `0` で `y` は `1`
     pub pos: usize,
+    /// パラメータの可変性
+    pub mutability: bool,
 }
 
 /// 型を表す

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -30,7 +30,7 @@ mod db;
 mod input;
 mod item;
 mod name_resolver;
-mod testing;
+pub mod testing;
 
 use std::{collections::HashMap, marker::PhantomData};
 
@@ -42,7 +42,6 @@ pub use item::{Function, Item, Module, ModuleKind, Param, Type, UseItem};
 use name_resolver::resolve_symbols;
 pub use name_resolver::{ModuleScopeOrigin, ResolutionMap, ResolutionStatus};
 use syntax::SyntaxNode;
-pub use testing::TestingDatabase;
 
 /// ビルド対象全体を表します。
 #[derive(Debug)]

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -514,10 +514,12 @@ pub struct Name {
 pub enum Stmt {
     /// 変数定義を表します。
     ///
-    /// 例: `let <name> = <value>;`
+    /// 例: `let [mut] <name> = <value>;`
     VariableDef {
         /// 変数名
         name: Name,
+        /// 可変性
+        is_mutability: bool,
         /// 初期値
         value: ExprId,
     },

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -518,7 +518,7 @@ pub enum Stmt {
         /// 変数名
         name: Name,
         /// 可変性
-        is_mutability: bool,
+        mutable: bool,
         /// 初期値
         value: ExprId,
     },

--- a/crates/hir/src/name_resolver/module_scope.rs
+++ b/crates/hir/src/name_resolver/module_scope.rs
@@ -428,7 +428,7 @@ impl<'a> ModuleScopesBuilder<'a> {
         match stmt {
             crate::Stmt::VariableDef {
                 name: _,
-                is_mutability: _,
+                mutable: _,
                 value,
             } => {
                 self.build_expr(hir_file, current_scope_idx, *value);

--- a/crates/hir/src/name_resolver/module_scope.rs
+++ b/crates/hir/src/name_resolver/module_scope.rs
@@ -426,7 +426,11 @@ impl<'a> ModuleScopesBuilder<'a> {
 
     fn build_stmt(&mut self, hir_file: HirFile, current_scope_idx: ModuleScopeIdx, stmt: &Stmt) {
         match stmt {
-            crate::Stmt::VariableDef { name: _, value } => {
+            crate::Stmt::VariableDef {
+                name: _,
+                is_mutability: _,
+                value,
+            } => {
                 self.build_expr(hir_file, current_scope_idx, *value);
             }
             crate::Stmt::ExprStmt {

--- a/crates/hir/src/testing.rs
+++ b/crates/hir/src/testing.rs
@@ -62,7 +62,7 @@ pub fn format_parameter(db: &dyn HirMasterDatabase, param_data: &ParamData) -> S
     } else {
         "<missing>"
     };
-    let mutable_text = if param_data.mutability { "mut " } else { "" };
+    let mutable_text = format_mutable(param_data.mutable);
     let ty = match param_data.ty {
         Type::Integer => "int",
         Type::String => "string",
@@ -72,4 +72,12 @@ pub fn format_parameter(db: &dyn HirMasterDatabase, param_data: &ParamData) -> S
         Type::Unknown => "<unknown>",
     };
     format!("{name}: {mutable_text}{ty}")
+}
+
+pub fn format_mutable(mutable: bool) -> &'static str {
+    if mutable {
+        "mut "
+    } else {
+        ""
+    }
 }

--- a/crates/hir/src/testing.rs
+++ b/crates/hir/src/testing.rs
@@ -2,6 +2,8 @@ use std::sync::{Arc, Mutex};
 
 use salsa::DebugWithDb;
 
+use crate::{item::ParamData, HirMasterDatabase, Type};
+
 /// SalsaのDB
 #[derive(Default)]
 #[salsa::db(crate::Jar)]
@@ -51,4 +53,23 @@ impl salsa::ParallelDatabase for TestingDatabase {
             logs: self.logs.clone(),
         })
     }
+}
+
+/// HIRの[ParamData]をテスト向けにフォーマットします。
+pub fn format_parameter(db: &dyn HirMasterDatabase, param_data: &ParamData) -> String {
+    let name = if let Some(name) = param_data.name {
+        name.text(db)
+    } else {
+        "<missing>"
+    };
+    let mutable_text = if param_data.mutability { "mut " } else { "" };
+    let ty = match param_data.ty {
+        Type::Integer => "int",
+        Type::String => "string",
+        Type::Char => "char",
+        Type::Boolean => "bool",
+        Type::Unit => "()",
+        Type::Unknown => "<unknown>",
+    };
+    format!("{name}: {mutable_text}{ty}")
 }

--- a/crates/hir_ty/src/inference.rs
+++ b/crates/hir_ty/src/inference.rs
@@ -216,7 +216,7 @@ impl<'a> InferBody<'a> {
         let ty = match stmt {
             hir::Stmt::VariableDef {
                 name: _,
-                is_mutability: _,
+                mutable: _,
                 value,
             } => {
                 let ty = self.infer_expr(*value);

--- a/crates/hir_ty/src/inference.rs
+++ b/crates/hir_ty/src/inference.rs
@@ -214,7 +214,11 @@ impl<'a> InferBody<'a> {
 
     fn infer_stmt(&mut self, stmt: &hir::Stmt) -> bool {
         let ty = match stmt {
-            hir::Stmt::VariableDef { name: _, value } => {
+            hir::Stmt::VariableDef {
+                name: _,
+                is_mutability: _,
+                value,
+            } => {
                 let ty = self.infer_expr(*value);
                 let ty_scheme = TypeScheme::new(ty.clone());
                 self.mut_current_scope().insert(*value, ty_scheme);

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -552,17 +552,13 @@ mod tests {
             match stmt {
                 hir::Stmt::VariableDef {
                     name,
-                    is_mutability,
+                    mutable,
                     value,
                 } => {
                     let indent = indent(nesting);
                     let name = name.text(self.db);
                     let expr_str = self.debug_expr(hir_file, function, *value, nesting);
-                    let mut_text = if *is_mutability {
-                        "mut ".to_string()
-                    } else {
-                        "".to_string()
-                    };
+                    let mut_text = hir::testing::format_mutable(*mutable);
                     let mut stmt_str = format!("{indent}let {mut_text}{name} = {expr_str};");
 
                     let type_line = self.debug_type_line(function, *value);

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -451,21 +451,7 @@ mod tests {
                 .iter()
                 .map(|param| {
                     let param_data = param.data(hir_file.db(self.db));
-                    let name = if let Some(name) = param_data.name {
-                        name.text(self.db)
-                    } else {
-                        "<missing>"
-                    };
-                    let mut_text = if param_data.mutability { "mut " } else { "" };
-                    let ty = match param_data.ty {
-                        hir::Type::Integer => "int",
-                        hir::Type::String => "string",
-                        hir::Type::Char => "char",
-                        hir::Type::Boolean => "bool",
-                        hir::Type::Unit => "()",
-                        hir::Type::Unknown => "<unknown>",
-                    };
-                    format!("{name}: {mut_text}{ty}")
+                    hir::testing::format_parameter(self.db, param_data)
                 })
                 .collect::<Vec<_>>()
                 .join(", ");

--- a/crates/lexer/src/token_kind.rs
+++ b/crates/lexer/src/token_kind.rs
@@ -60,6 +60,9 @@ pub enum TokenKind {
     /// `while`
     #[token("while")]
     WhileKw,
+    /// `mut
+    #[token("mut")]
+    MutKw,
 
     // identifier
     /// `[A-Za-z_][A-Za-z0-9_]*`
@@ -194,6 +197,7 @@ impl fmt::Display for TokenKind {
             Self::WhileKw => "'while'",
             Self::ContinueKw => "'continue'",
             Self::BreakKw => "'break'",
+            Self::MutKw => "'mut'",
             Self::Ident => "identifier",
             Self::IntegerLiteral => "integerLiteral",
             Self::StringLiteral => "stringLiteral",
@@ -313,6 +317,11 @@ mod tests {
     #[test]
     fn lex_while_keyword() {
         check("while", TokenKind::WhileKw);
+    }
+
+    #[test]
+    fn lex_mut_keyword() {
+        check("mut", TokenKind::MutKw);
     }
 
     #[test]

--- a/crates/mir/src/body.rs
+++ b/crates/mir/src/body.rs
@@ -589,7 +589,11 @@ impl<'a> FunctionLower<'a> {
 
     fn lower_stmt(&mut self, stmt: &hir::Stmt) -> LoweredStmt {
         match stmt {
-            hir::Stmt::VariableDef { name: _, value } => {
+            hir::Stmt::VariableDef {
+                name: _,
+                value,
+                is_mutability: _,
+            } => {
                 let local_idx = self.alloc_local(*value);
                 let operand = match self.lower_expr(*value) {
                     LoweredExpr::Operand(operand) => operand,

--- a/crates/mir/src/body.rs
+++ b/crates/mir/src/body.rs
@@ -592,7 +592,7 @@ impl<'a> FunctionLower<'a> {
             hir::Stmt::VariableDef {
                 name: _,
                 value,
-                is_mutability: _,
+                mutable: _,
             } => {
                 let local_idx = self.alloc_local(*value);
                 let operand = match self.lower_expr(*value) {

--- a/crates/parser/src/grammar/stmt.rs
+++ b/crates/parser/src/grammar/stmt.rs
@@ -25,6 +25,10 @@ fn parse_variable_def(parser: &mut Parser) -> CompletedNodeMarker {
     let marker = parser.start();
     parser.bump();
 
+    if parser.at(TokenKind::MutKw) {
+        parser.bump();
+    }
+
     parser.expect_with_block_recovery_set(TokenKind::Ident, &[TokenKind::Eq]);
     parser.expect_on_block(TokenKind::Eq);
 
@@ -249,6 +253,28 @@ mod tests {
     }
 
     #[test]
+    fn parse_variable_definition_mutable() {
+        check_debug_tree_in_block(
+            "let mut foo = 10;",
+            expect![[r#"
+                SourceFile@0..17
+                  VariableDef@0..17
+                    LetKw@0..3 "let"
+                    Whitespace@3..4 " "
+                    MutKw@4..7 "mut"
+                    Whitespace@7..8 " "
+                    Ident@8..11 "foo"
+                    Whitespace@11..12 " "
+                    Eq@12..13 "="
+                    Whitespace@13..14 " "
+                    Literal@14..16
+                      Integer@14..16 "10"
+                    Semicolon@16..17 ";"
+            "#]],
+        );
+    }
+
+    #[test]
     fn parse_varialbe_def_without_eq() {
         check_debug_tree_in_block(
             "let foo 10",
@@ -280,7 +306,7 @@ mod tests {
                     Whitespace@5..6 " "
                     Literal@6..8
                       Integer@6..8 "10"
-                error at 4..5: expected identifier, but found '='
+                error at 4..5: expected 'mut' or identifier, but found '='
             "#]],
         )
     }

--- a/crates/parser/src/grammar/stmt.rs
+++ b/crates/parser/src/grammar/stmt.rs
@@ -112,6 +112,11 @@ fn parse_params(parser: &mut Parser, recovery_set: &[TokenKind]) -> CompletedNod
             parser.bump();
 
             parser.expect_with_recovery_set_no_default(TokenKind::Colon, recovery_set);
+
+            if parser.at(TokenKind::MutKw) {
+                parser.bump();
+            }
+
             if parser.at(TokenKind::Ident) {
                 {
                     let marker = parser.start();
@@ -127,6 +132,10 @@ fn parse_params(parser: &mut Parser, recovery_set: &[TokenKind]) -> CompletedNod
                 let marker = parser.start();
                 parser.expect_with_recovery_set_no_default(TokenKind::Ident, recovery_set);
                 parser.expect_with_recovery_set_no_default(TokenKind::Colon, recovery_set);
+
+                if parser.at(TokenKind::MutKw) {
+                    parser.bump();
+                }
 
                 if parser.at(TokenKind::Ident) {
                     {
@@ -463,6 +472,51 @@ mod tests {
     }
 
     #[test]
+    fn parse_function_with_params_definition_mutable() {
+        check_debug_tree_in_block(
+            "fn foo(a: mut int, b: mut int) -> int {}",
+            expect![[r#"
+                SourceFile@0..40
+                  FunctionDef@0..40
+                    FnKw@0..2 "fn"
+                    Whitespace@2..3 " "
+                    Ident@3..6 "foo"
+                    ParamList@6..30
+                      LParen@6..7 "("
+                      Param@7..17
+                        Ident@7..8 "a"
+                        Colon@8..9 ":"
+                        Whitespace@9..10 " "
+                        MutKw@10..13 "mut"
+                        Whitespace@13..14 " "
+                        Type@14..17
+                          Ident@14..17 "int"
+                      Comma@17..18 ","
+                      Whitespace@18..19 " "
+                      Param@19..29
+                        Ident@19..20 "b"
+                        Colon@20..21 ":"
+                        Whitespace@21..22 " "
+                        MutKw@22..25 "mut"
+                        Whitespace@25..26 " "
+                        Type@26..29
+                          Ident@26..29 "int"
+                      RParen@29..30 ")"
+                    Whitespace@30..31 " "
+                    ReturnType@31..37
+                      ThinArrow@31..33 "->"
+                      Whitespace@33..34 " "
+                      Type@34..37
+                        Ident@34..37 "int"
+                    Whitespace@37..38 " "
+                    BlockExpr@38..40
+                      LCurly@38..39 "{"
+                      RCurly@39..40 "}"
+            "#]],
+        );
+    }
+
+    #[test]
     fn parse_function_with_block_definition() {
         check_debug_tree_in_block(
             "fn foo() -> int { 10 + 20 }",
@@ -538,7 +592,7 @@ mod tests {
                       Whitespace@28..29 " "
                       RCurly@29..30 "}"
                 error at 17..19: expected ':', but found ->
-                error at 17..19: expected identifier, ',' or ')', but found ->
+                error at 17..19: expected 'mut', identifier, ',' or ')', but found ->
             "#]],
         );
 
@@ -577,7 +631,7 @@ mod tests {
                       RCurly@27..28 "}"
                 error at 15..17: expected identifier, but found ->
                 error at 15..17: expected ':', but found ->
-                error at 15..17: expected identifier, ',' or ')', but found ->
+                error at 15..17: expected 'mut', identifier, ',' or ')', but found ->
             "#]],
         );
 
@@ -644,7 +698,7 @@ mod tests {
                           Integer@19..21 "10"
                       Whitespace@21..22 " "
                       RCurly@22..23 "}"
-                error at 10..12: expected identifier, ',' or ')', but found ->
+                error at 10..12: expected 'mut', identifier, ',' or ')', but found ->
             "#]],
         );
 
@@ -676,7 +730,7 @@ mod tests {
                       Whitespace@20..21 " "
                       RCurly@21..22 "}"
                 error at 9..11: expected ':', but found ->
-                error at 9..11: expected identifier, ',' or ')', but found ->
+                error at 9..11: expected 'mut', identifier, ',' or ')', but found ->
             "#]],
         );
 

--- a/crates/parser/src/grammar/toplevel.rs
+++ b/crates/parser/src/grammar/toplevel.rs
@@ -209,7 +209,7 @@ mod tests {
                       Whitespace@28..29 " "
                       RCurly@29..30 "}"
                 error at 17..19: expected ':', but found ->
-                error at 17..19: expected identifier, ',' or ')', but found ->
+                error at 17..19: expected 'mut', identifier, ',' or ')', but found ->
             "#]],
         );
 
@@ -248,7 +248,7 @@ mod tests {
                       RCurly@27..28 "}"
                 error at 15..17: expected identifier, but found ->
                 error at 15..17: expected ':', but found ->
-                error at 15..17: expected identifier, ',' or ')', but found ->
+                error at 15..17: expected 'mut', identifier, ',' or ')', but found ->
             "#]],
         );
 
@@ -315,7 +315,7 @@ mod tests {
                           Integer@19..21 "10"
                       Whitespace@21..22 " "
                       RCurly@22..23 "}"
-                error at 10..12: expected identifier, ',' or ')', but found ->
+                error at 10..12: expected 'mut', identifier, ',' or ')', but found ->
             "#]],
         );
 
@@ -347,7 +347,7 @@ mod tests {
                       Whitespace@20..21 " "
                       RCurly@21..22 "}"
                 error at 9..11: expected ':', but found ->
-                error at 9..11: expected identifier, ',' or ')', but found ->
+                error at 9..11: expected 'mut', identifier, ',' or ')', but found ->
             "#]],
         );
 

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -124,6 +124,7 @@ pub enum SyntaxKind {
     BreakKw,
 
     // ident modifiers
+    /// `mut`
     MutKw,
 
     // ---identifier---

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -122,6 +122,7 @@ pub enum SyntaxKind {
     ContinueKw,
     /// `break`
     BreakKw,
+    MutKw,
 
     // ---identifier---
     /// `IDENT`
@@ -211,6 +212,7 @@ impl From<TokenKind> for SyntaxKind {
             TokenKind::WhileKw => Self::WhileKw,
             TokenKind::ContinueKw => Self::ContinueKw,
             TokenKind::BreakKw => Self::BreakKw,
+            TokenKind::MutKw => Self::MutKw,
 
             TokenKind::Ident => Self::Ident,
 

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -122,6 +122,8 @@ pub enum SyntaxKind {
     ContinueKw,
     /// `break`
     BreakKw,
+
+    // ident modifiers
     MutKw,
 
     // ---identifier---


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Added support for parsing and handling the `mut` keyword across various components including lexer, parser, AST, and HIR.
- Enhanced AST and HIR nodes to include methods for retrieving mutability tokens.
- Updated type inference and lowering logic to handle mutability in variable and parameter definitions.
- Extended documentation in README to include detailed examples of reference and copy semantics in Rust.



___



___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - 変数定義と関数パラメータにおける変更可能性（mutability）を示す新しいキーワード「mut」を追加しました。
  - 構文解析機能が「mut」キーワードを正しく認識し、エラーメッセージにも反映されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->