### PR TITLE
Standardize AST node naming by renaming VariableDef to Let across the codebase

### DIFF
--- a/crates/ast/src/nodes.rs
+++ b/crates/ast/src/nodes.rs
@@ -9,17 +9,17 @@ use crate::{
 ///
 /// # Example
 ///
-/// このマクロは、`def_ast_node(VariableDef);`と呼び出すと以下のように展開されます。
+/// このマクロは、`def_ast_node(Let);`と呼び出すと以下のように展開されます。
 /// ```ignore
 /// #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-/// pub struct VariableDef {
+/// pub struct Let {
 ///     syntax: SyntaxNode,
 /// }
 ///
-/// impl Ast for VariableDef {}
-/// impl AstNode for VariableDef {
+/// impl Ast for Let {}
+/// impl AstNode for Let {
 ///     fn can_cast(kind: SyntaxKind) -> bool {
-///         kind == SyntaxKind::VariableDef
+///         kind == SyntaxKind::Let
 ///     }
 ///
 ///     fn cast(syntax: SyntaxNode) -> Option<Self> {
@@ -67,9 +67,9 @@ macro_rules! def_ast_node {
 
 def_ast_node!(
     /// 変数定義のASTノード
-    VariableDef
+    Let
 );
-impl VariableDef {
+impl Let {
     /// 変数の可変定義に位置する`mut`トークンを返します。
     pub fn mut_token(&self) -> Option<SyntaxToken> {
         ast_node::token(&self.syntax, SyntaxKind::MutKw)
@@ -197,7 +197,7 @@ impl AstNode for Expr {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Stmt {
     /// 変数定義
-    VariableDef(VariableDef),
+    Let(Let),
     /// 式ステートメント
     ExprStmt(ExprStmt),
     /// アイテム
@@ -206,12 +206,12 @@ pub enum Stmt {
 impl Ast for Stmt {}
 impl AstNode for Stmt {
     fn can_cast(kind: SyntaxKind) -> bool {
-        matches!(kind, SyntaxKind::VariableDef | SyntaxKind::ExprStmt) || Item::can_cast(kind)
+        matches!(kind, SyntaxKind::Let | SyntaxKind::ExprStmt) || Item::can_cast(kind)
     }
 
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let result = match syntax.kind() {
-            SyntaxKind::VariableDef => Self::VariableDef(VariableDef { syntax }),
+            SyntaxKind::Let => Self::Let(Let { syntax }),
             SyntaxKind::ExprStmt => Self::ExprStmt(ExprStmt::cast(syntax)?),
             _ => {
                 if let Some(item) = Item::cast(syntax) {
@@ -226,7 +226,7 @@ impl AstNode for Stmt {
 
     fn syntax(&self) -> &SyntaxNode {
         match self {
-            Stmt::VariableDef(it) => it.syntax(),
+            Stmt::Let(it) => it.syntax(),
             Stmt::ExprStmt(it) => it.syntax(),
             Stmt::Item(it) => it.syntax(),
         }

--- a/crates/hir/src/body.rs
+++ b/crates/hir/src/body.rs
@@ -362,11 +362,11 @@ impl<'a> BodyLower<'a> {
 
     fn lower_stmt(&mut self, db: &dyn HirMasterDatabase, ast_stmt: ast::Stmt) -> Option<Stmt> {
         let result = match ast_stmt {
-            ast::Stmt::VariableDef(def) => {
+            ast::Stmt::Let(def) => {
                 let expr = self.lower_expr(db, def.value());
                 let name = Name::new(db, def.name()?.name().to_owned());
                 self.scopes.define(name, expr);
-                Stmt::VariableDef {
+                Stmt::Let {
                     name,
                     mutable: def.mut_token().is_some(),
                     value: expr,
@@ -944,7 +944,7 @@ mod tests {
         nesting: usize,
     ) -> String {
         match stmt {
-            Stmt::VariableDef {
+            Stmt::Let {
                 name,
                 mutable,
                 value,
@@ -1283,7 +1283,7 @@ mod tests {
     }
 
     #[test]
-    fn lower_variable_def() {
+    fn lower_let() {
         check_in_root_file(
             r#"
                 fn main() {
@@ -1300,7 +1300,7 @@ mod tests {
     }
 
     #[test]
-    fn lower_variable_def_mutable() {
+    fn lower_let_mutable() {
         check_in_root_file(
             r#"
                 fn main() {
@@ -1317,7 +1317,7 @@ mod tests {
     }
 
     #[test]
-    fn lower_variable_def_without_name() {
+    fn lower_let_without_name() {
         check_in_root_file(
             r#"
                 fn main() {
@@ -1333,7 +1333,7 @@ mod tests {
     }
 
     #[test]
-    fn lower_variable_def_without_eq() {
+    fn lower_let_without_eq() {
         check_in_root_file(
             r#"
                 fn main() {
@@ -1350,7 +1350,7 @@ mod tests {
     }
 
     #[test]
-    fn lower_variable_def_without_value() {
+    fn lower_let_without_value() {
         check_in_root_file(
             r#"
                 fn main() {

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -514,7 +514,7 @@ pub enum Stmt {
     /// 変数定義を表します。
     ///
     /// 例: `let [mut] <name> = <value>;`
-    VariableDef {
+    Let {
         /// 変数名
         name: Name,
         /// 可変性
@@ -720,7 +720,7 @@ pub struct NameSolutionPath {
 /// ```nail
 /// {
 ///     let a = 10;
-/// } // Block { stmts: [Stmt::VariableDef { name: "a", value: ExprId(0) }], tail: None }
+/// } // Block { stmts: [Stmt::Let { name: "a", value: ExprId(0) }], tail: None }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Block {

--- a/crates/hir/src/name_resolver/module_scope.rs
+++ b/crates/hir/src/name_resolver/module_scope.rs
@@ -426,7 +426,7 @@ impl<'a> ModuleScopesBuilder<'a> {
 
     fn build_stmt(&mut self, hir_file: HirFile, current_scope_idx: ModuleScopeIdx, stmt: &Stmt) {
         match stmt {
-            crate::Stmt::VariableDef {
+            crate::Stmt::Let {
                 name: _,
                 mutable: _,
                 value,

--- a/crates/hir_ty/src/checker.rs
+++ b/crates/hir_ty/src/checker.rs
@@ -85,7 +85,7 @@ impl<'a> FunctionTypeChecker<'a> {
     fn check_stmt(&mut self, stmt: &'a hir::Stmt) {
         match stmt {
             hir::Stmt::ExprStmt { expr, .. } => self.check_expr(*expr),
-            hir::Stmt::VariableDef { value, .. } => self.check_expr(*value),
+            hir::Stmt::Let { value, .. } => self.check_expr(*value),
             hir::Stmt::Item { .. } => (),
         }
     }

--- a/crates/hir_ty/src/inference.rs
+++ b/crates/hir_ty/src/inference.rs
@@ -214,7 +214,7 @@ impl<'a> InferBody<'a> {
 
     fn infer_stmt(&mut self, stmt: &hir::Stmt) -> bool {
         let ty = match stmt {
-            hir::Stmt::VariableDef {
+            hir::Stmt::Let {
                 name: _,
                 mutable: _,
                 value,

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -550,7 +550,7 @@ mod tests {
             nesting: usize,
         ) -> String {
             match stmt {
-                hir::Stmt::VariableDef {
+                hir::Stmt::Let {
                     name,
                     mutable,
                     value,
@@ -1042,7 +1042,7 @@ mod tests {
     }
 
     #[test]
-    fn infer_variable_def() {
+    fn infer_let() {
         check_in_root_file(
             r#"
                 fn main() {
@@ -1064,7 +1064,7 @@ mod tests {
     }
 
     #[test]
-    fn infer_multiline_variable_def() {
+    fn infer_multiline_let() {
         check_in_root_file(
             r#"
                 fn main() {

--- a/crates/mir/src/body.rs
+++ b/crates/mir/src/body.rs
@@ -589,7 +589,7 @@ impl<'a> FunctionLower<'a> {
 
     fn lower_stmt(&mut self, stmt: &hir::Stmt) -> LoweredStmt {
         match stmt {
-            hir::Stmt::VariableDef {
+            hir::Stmt::Let {
                 name: _,
                 value,
                 mutable: _,

--- a/crates/parser/src/grammar/expr.rs
+++ b/crates/parser/src/grammar/expr.rs
@@ -828,7 +828,7 @@ mod tests {
                     Literal@0..2
                       Char@0..2 "'a"
                   Whitespace@2..3 " "
-                  VariableDef@3..13
+                  Let@3..13
                     LetKw@3..6 "let"
                     Whitespace@6..7 " "
                     Ident@7..8 "b"
@@ -1043,7 +1043,7 @@ mod tests {
                     BlockExpr@0..24
                       LCurly@0..1 "{"
                       Whitespace@1..4 "\n  "
-                      VariableDef@4..14
+                      Let@4..14
                         LetKw@4..7 "let"
                         Whitespace@7..8 " "
                         Ident@8..9 "a"
@@ -1454,7 +1454,7 @@ mod tests {
             "let a = if true { 10 } else { 20 }",
             expect![[r#"
                 SourceFile@0..34
-                  VariableDef@0..34
+                  Let@0..34
                     LetKw@0..3 "let"
                     Whitespace@3..4 " "
                     Ident@4..5 "a"

--- a/crates/parser/src/grammar/stmt.rs
+++ b/crates/parser/src/grammar/stmt.rs
@@ -9,7 +9,7 @@ use crate::parser::{marker::CompletedNodeMarker, Parser, BLOCK_RECOVERY_SET};
 /// トップレベルのステートメントのパースと区別するために定義しています。
 pub(super) fn parse_stmt_on_block(parser: &mut Parser) -> Option<CompletedNodeMarker> {
     if parser.at(TokenKind::LetKw) {
-        Some(parse_variable_def(parser))
+        Some(parse_let(parser))
     } else if parser.at(TokenKind::FnKw) {
         Some(parse_function_def(parser, &BLOCK_RECOVERY_SET))
     } else if parser.at(TokenKind::ModKw) {
@@ -20,7 +20,7 @@ pub(super) fn parse_stmt_on_block(parser: &mut Parser) -> Option<CompletedNodeMa
 }
 
 /// ローカル変数の定義をパースする
-fn parse_variable_def(parser: &mut Parser) -> CompletedNodeMarker {
+fn parse_let(parser: &mut Parser) -> CompletedNodeMarker {
     assert!(parser.at(TokenKind::LetKw));
     let marker = parser.start();
     parser.bump();
@@ -38,7 +38,7 @@ fn parse_variable_def(parser: &mut Parser) -> CompletedNodeMarker {
         parser.bump();
     }
 
-    marker.complete(parser, SyntaxKind::VariableDef)
+    marker.complete(parser, SyntaxKind::Let)
 }
 
 /// 関数定義をパースする
@@ -194,12 +194,12 @@ mod tests {
     use crate::check_debug_tree_in_block;
 
     #[test]
-    fn parse_variable_definition() {
+    fn parse_let() {
         check_debug_tree_in_block(
             "let foo = bar",
             expect![[r#"
                 SourceFile@0..13
-                  VariableDef@0..13
+                  Let@0..13
                     LetKw@0..3 "let"
                     Whitespace@3..4 " "
                     Ident@4..7 "foo"
@@ -242,12 +242,12 @@ mod tests {
     }
 
     #[test]
-    fn parse_variable_definition_with_semicolon() {
+    fn parse_let_with_semicolon() {
         check_debug_tree_in_block(
             "let foo = 10;",
             expect![[r#"
                 SourceFile@0..13
-                  VariableDef@0..13
+                  Let@0..13
                     LetKw@0..3 "let"
                     Whitespace@3..4 " "
                     Ident@4..7 "foo"
@@ -262,12 +262,12 @@ mod tests {
     }
 
     #[test]
-    fn parse_variable_definition_mutable() {
+    fn parse_let_mutable() {
         check_debug_tree_in_block(
             "let mut foo = 10;",
             expect![[r#"
                 SourceFile@0..17
-                  VariableDef@0..17
+                  Let@0..17
                     LetKw@0..3 "let"
                     Whitespace@3..4 " "
                     MutKw@4..7 "mut"
@@ -289,7 +289,7 @@ mod tests {
             "let foo 10",
             expect![[r#"
                 SourceFile@0..10
-                  VariableDef@0..10
+                  Let@0..10
                     LetKw@0..3 "let"
                     Whitespace@3..4 " "
                     Ident@4..7 "foo"
@@ -308,7 +308,7 @@ mod tests {
             "let = 10",
             expect![[r#"
                 SourceFile@0..8
-                  VariableDef@0..8
+                  Let@0..8
                     LetKw@0..3 "let"
                     Whitespace@3..4 " "
                     Eq@4..5 "="
@@ -326,14 +326,14 @@ mod tests {
             "let a =\nlet b = a",
             expect![[r#"
                 SourceFile@0..17
-                  VariableDef@0..7
+                  Let@0..7
                     LetKw@0..3 "let"
                     Whitespace@3..4 " "
                     Ident@4..5 "a"
                     Whitespace@5..6 " "
                     Eq@6..7 "="
                   Whitespace@7..8 "\n"
-                  VariableDef@8..17
+                  Let@8..17
                     LetKw@8..11 "let"
                     Whitespace@11..12 " "
                     Ident@12..13 "b"
@@ -384,7 +384,7 @@ mod tests {
             "let a = 1\na",
             expect![[r#"
                 SourceFile@0..11
-                  VariableDef@0..9
+                  Let@0..9
                     LetKw@0..3 "let"
                     Whitespace@3..4 " "
                     Ident@4..5 "a"

--- a/crates/parser/src/grammar/toplevel.rs
+++ b/crates/parser/src/grammar/toplevel.rs
@@ -82,7 +82,7 @@ mod tests {
     use crate::check_debug_tree;
 
     #[test]
-    fn parse_variable_definition() {
+    fn parse_let() {
         check_debug_tree(
             "let foo = bar",
             expect![[r#"

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -60,7 +60,7 @@ pub enum SyntaxKind {
 
     // ---statement nodes---
     /// `let IDENT: TYPE = EXPR`
-    VariableDef,
+    Let,
 
     // ---item nodes---
     /// `fn IDENT(ParamList) -> ReturnType BlockExpr`


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Renamed all instances of `VariableDef` to `Let` across multiple files to standardize naming.
- Updated related documentation, tests, and handling logic in various modules like AST, HIR, MIR, and parser.
- Adjusted type checking and inference logic to accommodate the new `Let` naming.



___



___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 変数定義の構文が `VariableDef` から `Let` に変更されました。これにより、コードの可読性が向上し、より現代的なプログラミングスタイルに対応します。

- **リファクタリング**
  - 複数の内部コンポーネントで `VariableDef` の使用が `Let` に統一され、一貫性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->