### PR TITLE
Rename ExprStmt to Expr across multiple modules and update associated handling

### DIFF
--- a/crates/ast/src/nodes.rs
+++ b/crates/ast/src/nodes.rs
@@ -199,7 +199,7 @@ pub enum Stmt {
     /// 変数定義
     Let(Let),
     /// 式ステートメント
-    ExprStmt(ExprStmt),
+    Expr(ExprStmt),
     /// アイテム
     Item(Item),
 }
@@ -212,7 +212,7 @@ impl AstNode for Stmt {
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let result = match syntax.kind() {
             SyntaxKind::Let => Self::Let(Let { syntax }),
-            SyntaxKind::ExprStmt => Self::ExprStmt(ExprStmt::cast(syntax)?),
+            SyntaxKind::ExprStmt => Self::Expr(ExprStmt::cast(syntax)?),
             _ => {
                 if let Some(item) = Item::cast(syntax) {
                     return Some(Stmt::Item(item));
@@ -227,7 +227,7 @@ impl AstNode for Stmt {
     fn syntax(&self) -> &SyntaxNode {
         match self {
             Stmt::Let(it) => it.syntax(),
-            Stmt::ExprStmt(it) => it.syntax(),
+            Stmt::Expr(it) => it.syntax(),
             Stmt::Item(it) => it.syntax(),
         }
     }

--- a/crates/hir/src/body.rs
+++ b/crates/hir/src/body.rs
@@ -372,9 +372,9 @@ impl<'a> BodyLower<'a> {
                     value: expr,
                 }
             }
-            ast::Stmt::ExprStmt(ast) => {
+            ast::Stmt::Expr(ast) => {
                 let expr = self.lower_expr(db, ast.expr());
-                Stmt::ExprStmt {
+                Stmt::Expr {
                     expr,
                     has_semicolon: ast.semicolon().is_some(),
                 }
@@ -606,7 +606,7 @@ impl<'a> BodyLower<'a> {
         self.scopes.leave();
 
         let tail = match stmts.last() {
-            Some(Stmt::ExprStmt {
+            Some(Stmt::Expr {
                 expr,
                 has_semicolon,
             }) if !has_semicolon => {
@@ -712,7 +712,7 @@ impl<'a> BodyLower<'a> {
             // while式の条件が一致しない場合にbreakするためのブロック
             let break_block = {
                 let break_block = Expr::Block(Block {
-                    stmts: vec![Stmt::ExprStmt {
+                    stmts: vec![Stmt::Expr {
                         expr: self.alloc_expr_desugared(
                             &ast::Expr::cast(ast_while.syntax().clone()).unwrap(),
                             Expr::Break { value: None },
@@ -733,7 +733,7 @@ impl<'a> BodyLower<'a> {
                 };
 
                 Expr::Block(Block {
-                    stmts: vec![Stmt::ExprStmt {
+                    stmts: vec![Stmt::Expr {
                         expr: self.alloc_expr_desugared(
                             &ast::Expr::cast(ast_while.syntax().clone()).unwrap(),
                             if_expr,
@@ -955,7 +955,7 @@ mod tests {
                 let mutable_text = crate::testing::format_mutable(*mutable);
                 format!("{}let {mutable_text}{name} = {expr_str}\n", indent(nesting))
             }
-            Stmt::ExprStmt {
+            Stmt::Expr {
                 expr,
                 has_semicolon,
             } => format!(

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -526,7 +526,7 @@ pub enum Stmt {
     ///
     /// 例: `<expr>`
     /// 例: `<expr>;`
-    ExprStmt {
+    Expr {
         /// 式
         expr: ExprId,
         /// セミコロンがあるかどうか

--- a/crates/hir/src/name_resolver/module_scope.rs
+++ b/crates/hir/src/name_resolver/module_scope.rs
@@ -433,7 +433,7 @@ impl<'a> ModuleScopesBuilder<'a> {
             } => {
                 self.build_expr(hir_file, current_scope_idx, *value);
             }
-            crate::Stmt::ExprStmt {
+            crate::Stmt::Expr {
                 expr,
                 has_semicolon: _,
             } => self.build_expr(hir_file, current_scope_idx, *expr),

--- a/crates/hir_ty/src/checker.rs
+++ b/crates/hir_ty/src/checker.rs
@@ -84,7 +84,7 @@ impl<'a> FunctionTypeChecker<'a> {
 
     fn check_stmt(&mut self, stmt: &'a hir::Stmt) {
         match stmt {
-            hir::Stmt::ExprStmt { expr, .. } => self.check_expr(*expr),
+            hir::Stmt::Expr { expr, .. } => self.check_expr(*expr),
             hir::Stmt::Let { value, .. } => self.check_expr(*value),
             hir::Stmt::Item { .. } => (),
         }

--- a/crates/hir_ty/src/inference.rs
+++ b/crates/hir_ty/src/inference.rs
@@ -224,7 +224,7 @@ impl<'a> InferBody<'a> {
                 self.mut_current_scope().insert(*value, ty_scheme);
                 ty
             }
-            hir::Stmt::ExprStmt {
+            hir::Stmt::Expr {
                 expr,
                 has_semicolon: _,
             } => self.infer_expr(*expr),

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -566,7 +566,7 @@ mod tests {
 
                     stmt_str
                 }
-                hir::Stmt::ExprStmt {
+                hir::Stmt::Expr {
                     expr,
                     has_semicolon,
                 } => {

--- a/crates/mir/src/body.rs
+++ b/crates/mir/src/body.rs
@@ -607,7 +607,7 @@ impl<'a> FunctionLower<'a> {
                     value: operand.into(),
                 });
             }
-            hir::Stmt::ExprStmt { expr, .. } => {
+            hir::Stmt::Expr { expr, .. } => {
                 match self.lower_expr(*expr) {
                     LoweredExpr::Operand(operand) => operand,
                     LoweredExpr::Return => {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Renamed `ExprStmt` to `Expr` across multiple modules affecting enums, methods, and tests.
- Updated associated methods in various modules to accommodate the renaming, ensuring consistency.
- Adjusted handling and inference of expressions to reflect the new naming convention.



___



___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタリング**
	- 式文を表す列挙体のメンバー名を `ExprStmt` から `Expr` に変更しました。これにより、式の扱いがより直感的になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->