### PR TITLE
Implement support for 'struct' keyword in lexer, parser, and syntax definitions


### DIFF
--- a/crates/lexer/src/token_kind.rs
+++ b/crates/lexer/src/token_kind.rs
@@ -22,6 +22,9 @@ pub enum TokenKind {
     /// `fn`
     #[token("fn")]
     FnKw,
+    /// `struct`
+    #[token("struct")]
+    StructKw,
     /// `mod`
     #[token("mod")]
     ModKw,
@@ -194,6 +197,7 @@ impl fmt::Display for TokenKind {
         f.write_str(match self {
             Self::Whitespace => "whitespace",
             Self::FnKw => "'fn'",
+            Self::StructKw => "'struct'",
             Self::ModKw => "'mod'",
             Self::UseKw => "'use'",
             Self::LetKw => "'let'",
@@ -269,6 +273,11 @@ mod tests {
     #[test]
     fn lex_fn_keyword() {
         check("fn", TokenKind::FnKw);
+    }
+
+    #[test]
+    fn lex_struct_keyword() {
+        check("struct", TokenKind::StructKw);
     }
 
     #[test]

--- a/crates/parser/src/grammar/expr.rs
+++ b/crates/parser/src/grammar/expr.rs
@@ -1348,7 +1348,7 @@ mod tests {
                     Error@5..6
                       RParen@5..6 ")"
                 error at 4..5: expected '::', '+', '-', '*', '/', '==', '!=', '>', '<', '>=', '<=', '=', ',' or ')', but found identifier
-                error at 5..6: expected '+', '-', '*', '/', '==', '!=', '>', '<', '>=', '<=', '=', ';', 'let', 'fn', 'mod', integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '!', '(', '{', 'if', 'return', 'loop', 'continue', 'break' or 'while', but found ')'
+                error at 5..6: expected '+', '-', '*', '/', '==', '!=', '>', '<', '>=', '<=', '=', ';', 'let', 'fn', 'struct', 'mod', integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '!', '(', '{', 'if', 'return', 'loop', 'continue', 'break' or 'while', but found ')'
             "#]],
         );
     }

--- a/crates/parser/src/grammar/stmt.rs
+++ b/crates/parser/src/grammar/stmt.rs
@@ -12,6 +12,8 @@ pub(super) fn parse_stmt_on_block(parser: &mut Parser) -> Option<CompletedNodeMa
         Some(parse_let(parser))
     } else if parser.at(TokenKind::FnKw) {
         Some(parse_function_def(parser, &BLOCK_RECOVERY_SET))
+    } else if parser.at(TokenKind::StructKw) {
+        Some(parse_struct(parser, &BLOCK_RECOVERY_SET))
     } else if parser.at(TokenKind::ModKw) {
         Some(toplevel::parse_module(parser, &BLOCK_RECOVERY_SET))
     } else {
@@ -79,6 +81,41 @@ pub(super) fn parse_function_def(
     }
 
     marker.complete(parser, SyntaxKind::FunctionDef)
+}
+
+/// 構造体定義をパースする
+pub(super) fn parse_struct(parser: &mut Parser, recovery_set: &[TokenKind]) -> CompletedNodeMarker {
+    assert!(parser.at(TokenKind::StructKw));
+
+    let marker = parser.start();
+    parser.bump();
+
+    parser.expect_with_recovery_set_no_default(
+        TokenKind::Ident,
+        &[
+            recovery_set,
+            &[TokenKind::LParen, TokenKind::LCurly, TokenKind::Semicolon],
+        ]
+        .concat(),
+    );
+
+    // No body struct
+    if parser.at(TokenKind::Semicolon) {
+        parser.bump();
+    }
+    // or tuple fields struct
+    else if parser.at(TokenKind::LParen) {
+        parse_tuple_fields(parser, recovery_set);
+        if parser.at(TokenKind::Semicolon) {
+            parser.bump();
+        }
+    }
+    // or record fields struct
+    else if parser.at(TokenKind::LCurly) {
+        parse_record_fields(parser, recovery_set);
+    }
+
+    marker.complete(parser, SyntaxKind::StructDef)
 }
 
 /// ステートメントをパースする
@@ -185,6 +222,122 @@ fn parse_block(parser: &mut Parser) -> CompletedNodeMarker {
     parser.expect_on_block(TokenKind::RCurly);
 
     marker.complete(parser, SyntaxKind::BlockExpr)
+}
+
+/// 構造体のレコードフィールドをパースする
+///
+/// 構造体定義はトップレベルとブロック内でパースするため、
+/// それぞれに合わせて復帰トークン種別を`recovery_set`に指定可能にしています。
+fn parse_record_fields(parser: &mut Parser, recovery_set: &[TokenKind]) -> CompletedNodeMarker {
+    assert!(parser.at(TokenKind::LCurly));
+
+    let recovery_set = &[
+        recovery_set,
+        &[TokenKind::Comma, TokenKind::Colon, TokenKind::RCurly],
+    ]
+    .concat();
+
+    let marker = parser.start();
+    parser.bump();
+
+    if parser.at(TokenKind::Ident) || parser.at(TokenKind::Colon) || parser.at(TokenKind::Comma) {
+        {
+            let marker = parser.start();
+            parser.expect_with_recovery_set_no_default(TokenKind::Ident, recovery_set);
+            parser.expect_with_recovery_set_no_default(TokenKind::Colon, recovery_set);
+
+            if parser.at(TokenKind::Ident) {
+                {
+                    let marker = parser.start();
+                    parser.bump();
+                    marker.complete(parser, SyntaxKind::Type);
+                }
+            }
+            marker.complete(parser, SyntaxKind::RecordField);
+        }
+        while parser.at(TokenKind::Comma) {
+            parser.bump();
+            {
+                // struct AAA { a: int, b: int, }
+                //                            ^時点で停止させる
+                if parser.at(TokenKind::RCurly) {
+                    parser.bump();
+                    return marker.complete(parser, SyntaxKind::RecordFieldList);
+                }
+
+                let marker = parser.start();
+                parser.expect_with_recovery_set_no_default(TokenKind::Ident, recovery_set);
+                parser.expect_with_recovery_set_no_default(TokenKind::Colon, recovery_set);
+
+                if parser.at(TokenKind::Ident) {
+                    {
+                        let marker = parser.start();
+                        parser.bump();
+                        marker.complete(parser, SyntaxKind::Type);
+                    }
+                }
+                marker.complete(parser, SyntaxKind::RecordField);
+            }
+        }
+    }
+    parser.expect_with_recovery_set_no_default(TokenKind::RCurly, recovery_set);
+
+    marker.complete(parser, SyntaxKind::RecordFieldList)
+}
+
+/// 構造体のタプルフィールドをパースする
+///
+/// 構造体定義はトップレベルとブロック内でパースするため、
+/// それぞれに合わせて復帰トークン種別を`recovery_set`に指定可能にしています。
+fn parse_tuple_fields(parser: &mut Parser, recovery_set: &[TokenKind]) -> CompletedNodeMarker {
+    assert!(parser.at(TokenKind::LParen));
+
+    let recovery_set = &[recovery_set, &[TokenKind::Comma, TokenKind::RParen]].concat();
+
+    let marker = parser.start();
+    parser.bump();
+
+    if parser.at(TokenKind::Ident) {
+        {
+            let marker = parser.start();
+            parser.bump();
+
+            if parser.at(TokenKind::Ident) {
+                {
+                    let marker = parser.start();
+                    parser.bump();
+                    marker.complete(parser, SyntaxKind::Type);
+                }
+            }
+            marker.complete(parser, SyntaxKind::TupleField);
+        }
+        while parser.at(TokenKind::Comma) {
+            parser.bump();
+            {
+                // struct AAA(i32, i32,);
+                //                    ^時点で停止させる(`(`は`parse_struct`側でbump)
+                if parser.at(TokenKind::RParen) {
+                    parser.bump();
+                    return marker.complete(parser, SyntaxKind::TupleFieldList);
+                }
+
+                let marker = parser.start();
+                parser.expect_with_recovery_set_no_default(TokenKind::Ident, recovery_set);
+
+                if parser.at(TokenKind::Ident) {
+                    {
+                        let marker = parser.start();
+                        parser.bump();
+                        marker.complete(parser, SyntaxKind::Type);
+                    }
+                }
+                marker.complete(parser, SyntaxKind::TupleField);
+            }
+        }
+    }
+    parser.expect_with_recovery_set_no_default(TokenKind::RParen, recovery_set);
+
+    marker.complete(parser, SyntaxKind::TupleFieldList)
 }
 
 #[cfg(test)]
@@ -884,6 +1037,309 @@ mod tests {
                           Integer@13..15 "10"
                       Whitespace@15..16 " "
                       RCurly@16..17 "}"
+            "#]],
+        );
+    }
+
+    #[test]
+    fn parse_struct_definition_empty_fields() {
+        check_debug_tree_in_block(
+            r#"
+struct AAA;
+            "#,
+            expect![[r#"
+                SourceFile@0..25
+                  Whitespace@0..1 "\n"
+                  StructDef@1..12
+                    StructKw@1..7 "struct"
+                    Whitespace@7..8 " "
+                    Ident@8..11 "AAA"
+                    Semicolon@11..12 ";"
+                  Whitespace@12..25 "\n            "
+            "#]],
+        );
+    }
+
+    #[test]
+    fn parse_struct_definition_tuple_fields() {
+        check_debug_tree_in_block(
+            r#"
+struct AAA();
+struct AAA(int, int);
+struct AAA(int, int,);
+            "#,
+            expect![[r#"
+                SourceFile@0..72
+                  Whitespace@0..1 "\n"
+                  StructDef@1..14
+                    StructKw@1..7 "struct"
+                    Whitespace@7..8 " "
+                    Ident@8..11 "AAA"
+                    TupleFieldList@11..13
+                      LParen@11..12 "("
+                      RParen@12..13 ")"
+                    Semicolon@13..14 ";"
+                  Whitespace@14..15 "\n"
+                  StructDef@15..36
+                    StructKw@15..21 "struct"
+                    Whitespace@21..22 " "
+                    Ident@22..25 "AAA"
+                    TupleFieldList@25..35
+                      LParen@25..26 "("
+                      TupleField@26..29
+                        Ident@26..29 "int"
+                      Comma@29..30 ","
+                      Whitespace@30..31 " "
+                      TupleField@31..34
+                        Ident@31..34 "int"
+                      RParen@34..35 ")"
+                    Semicolon@35..36 ";"
+                  Whitespace@36..37 "\n"
+                  StructDef@37..59
+                    StructKw@37..43 "struct"
+                    Whitespace@43..44 " "
+                    Ident@44..47 "AAA"
+                    TupleFieldList@47..58
+                      LParen@47..48 "("
+                      TupleField@48..51
+                        Ident@48..51 "int"
+                      Comma@51..52 ","
+                      Whitespace@52..53 " "
+                      TupleField@53..56
+                        Ident@53..56 "int"
+                      Comma@56..57 ","
+                      RParen@57..58 ")"
+                    Semicolon@58..59 ";"
+                  Whitespace@59..72 "\n            "
+            "#]],
+        );
+    }
+
+    #[test]
+    fn parse_struct_definition_record_fields() {
+        check_debug_tree_in_block(
+            r#"
+struct AAA {
+}
+struct AAA {
+    a: int,
+    b: int
+}
+struct AAA {
+    a: int,
+    b: int,
+}
+            "#,
+            expect![[r#"
+                SourceFile@0..105
+                  Whitespace@0..1 "\n"
+                  StructDef@1..15
+                    StructKw@1..7 "struct"
+                    Whitespace@7..8 " "
+                    Ident@8..11 "AAA"
+                    Whitespace@11..12 " "
+                    RecordFieldList@12..15
+                      LCurly@12..13 "{"
+                      Whitespace@13..14 "\n"
+                      RCurly@14..15 "}"
+                  Whitespace@15..16 "\n"
+                  StructDef@16..53
+                    StructKw@16..22 "struct"
+                    Whitespace@22..23 " "
+                    Ident@23..26 "AAA"
+                    Whitespace@26..27 " "
+                    RecordFieldList@27..53
+                      LCurly@27..28 "{"
+                      Whitespace@28..33 "\n    "
+                      RecordField@33..39
+                        Ident@33..34 "a"
+                        Colon@34..35 ":"
+                        Whitespace@35..36 " "
+                        Type@36..39
+                          Ident@36..39 "int"
+                      Comma@39..40 ","
+                      Whitespace@40..45 "\n    "
+                      RecordField@45..51
+                        Ident@45..46 "b"
+                        Colon@46..47 ":"
+                        Whitespace@47..48 " "
+                        Type@48..51
+                          Ident@48..51 "int"
+                      Whitespace@51..52 "\n"
+                      RCurly@52..53 "}"
+                  Whitespace@53..54 "\n"
+                  StructDef@54..92
+                    StructKw@54..60 "struct"
+                    Whitespace@60..61 " "
+                    Ident@61..64 "AAA"
+                    Whitespace@64..65 " "
+                    RecordFieldList@65..92
+                      LCurly@65..66 "{"
+                      Whitespace@66..71 "\n    "
+                      RecordField@71..77
+                        Ident@71..72 "a"
+                        Colon@72..73 ":"
+                        Whitespace@73..74 " "
+                        Type@74..77
+                          Ident@74..77 "int"
+                      Comma@77..78 ","
+                      Whitespace@78..83 "\n    "
+                      RecordField@83..89
+                        Ident@83..84 "b"
+                        Colon@84..85 ":"
+                        Whitespace@85..86 " "
+                        Type@86..89
+                          Ident@86..89 "int"
+                      Comma@89..90 ","
+                      Whitespace@90..91 "\n"
+                      RCurly@91..92 "}"
+                  Whitespace@92..105 "\n            "
+            "#]],
+        );
+    }
+
+    #[test]
+    fn parse_struct_definition_missing() {
+        check_debug_tree_in_block(
+            r#"
+struct ;
+            "#,
+            expect![[r#"
+                SourceFile@0..22
+                  Whitespace@0..1 "\n"
+                  StructDef@1..9
+                    StructKw@1..7 "struct"
+                    Whitespace@7..8 " "
+                    Semicolon@8..9 ";"
+                  Whitespace@9..22 "\n            "
+                error at 8..9: expected identifier, but found ';'
+            "#]],
+        );
+
+        check_debug_tree_in_block(
+            r#"
+struct ;
+            "#,
+            expect![[r#"
+                SourceFile@0..22
+                  Whitespace@0..1 "\n"
+                  StructDef@1..9
+                    StructKw@1..7 "struct"
+                    Whitespace@7..8 " "
+                    Semicolon@8..9 ";"
+                  Whitespace@9..22 "\n            "
+                error at 8..9: expected identifier, but found ';'
+            "#]],
+        );
+
+        check_debug_tree_in_block(
+            r#"
+struct (i32);
+            "#,
+            expect![[r#"
+                SourceFile@0..27
+                  Whitespace@0..1 "\n"
+                  StructDef@1..14
+                    StructKw@1..7 "struct"
+                    Whitespace@7..8 " "
+                    TupleFieldList@8..13
+                      LParen@8..9 "("
+                      TupleField@9..12
+                        Ident@9..12 "i32"
+                      RParen@12..13 ")"
+                    Semicolon@13..14 ";"
+                  Whitespace@14..27 "\n            "
+                error at 8..9: expected identifier, but found '('
+            "#]],
+        );
+
+        check_debug_tree_in_block(
+            r#"
+struct { a: i32 }
+            "#,
+            expect![[r#"
+                SourceFile@0..31
+                  Whitespace@0..1 "\n"
+                  StructDef@1..18
+                    StructKw@1..7 "struct"
+                    Whitespace@7..8 " "
+                    RecordFieldList@8..18
+                      LCurly@8..9 "{"
+                      Whitespace@9..10 " "
+                      RecordField@10..16
+                        Ident@10..11 "a"
+                        Colon@11..12 ":"
+                        Whitespace@12..13 " "
+                        Type@13..16
+                          Ident@13..16 "i32"
+                      Whitespace@16..17 " "
+                      RCurly@17..18 "}"
+                  Whitespace@18..31 "\n            "
+                error at 8..9: expected identifier, but found '{'
+            "#]],
+        );
+
+        check_debug_tree_in_block(
+            r#"
+struct AAA { : i32, : bool }
+            "#,
+            expect![[r#"
+                SourceFile@0..42
+                  Whitespace@0..1 "\n"
+                  StructDef@1..29
+                    StructKw@1..7 "struct"
+                    Whitespace@7..8 " "
+                    Ident@8..11 "AAA"
+                    Whitespace@11..12 " "
+                    RecordFieldList@12..29
+                      LCurly@12..13 "{"
+                      Whitespace@13..14 " "
+                      RecordField@14..19
+                        Colon@14..15 ":"
+                        Whitespace@15..16 " "
+                        Type@16..19
+                          Ident@16..19 "i32"
+                      Comma@19..20 ","
+                      Whitespace@20..21 " "
+                      RecordField@21..27
+                        Colon@21..22 ":"
+                        Whitespace@22..23 " "
+                        Type@23..27
+                          Ident@23..27 "bool"
+                      Whitespace@27..28 " "
+                      RCurly@28..29 "}"
+                  Whitespace@29..42 "\n            "
+                error at 14..15: expected identifier or ':', but found ':'
+                error at 21..22: expected '}' or identifier, but found ':'
+            "#]],
+        );
+
+        check_debug_tree_in_block(
+            r#"
+struct AAA { a:, b: }
+            "#,
+            expect![[r#"
+                SourceFile@0..35
+                  Whitespace@0..1 "\n"
+                  StructDef@1..22
+                    StructKw@1..7 "struct"
+                    Whitespace@7..8 " "
+                    Ident@8..11 "AAA"
+                    Whitespace@11..12 " "
+                    RecordFieldList@12..22
+                      LCurly@12..13 "{"
+                      Whitespace@13..14 " "
+                      RecordField@14..16
+                        Ident@14..15 "a"
+                        Colon@15..16 ":"
+                      Comma@16..17 ","
+                      Whitespace@17..18 " "
+                      RecordField@18..20
+                        Ident@18..19 "b"
+                        Colon@19..20 ":"
+                      Whitespace@20..21 " "
+                      RCurly@21..22 "}"
+                  Whitespace@22..35 "\n            "
             "#]],
         );
     }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -162,7 +162,7 @@ mod tests {
                               Ident@11..16 "hello"
                       Whitespace@16..17 " "
                       RCurly@17..18 "}"
-                error at 9..10: expected '}', 'let', 'fn', 'mod', integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '(', '{', 'if', 'return', 'loop', 'continue', 'break' or 'while', but found '/'
+                error at 9..10: expected '}', 'let', 'fn', 'struct', 'mod', integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '(', '{', 'if', 'return', 'loop', 'continue', 'break' or 'while', but found '/'
             "#]],
         );
     }

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -32,10 +32,15 @@ pub(crate) struct Parser<'l, 'input> {
 }
 
 /// トップレベルで回復可能なトークンの集合
-pub(crate) const TOPLEVEL_RECOVERY_SET: [TokenKind; 2] = [TokenKind::FnKw, TokenKind::ModKw];
+pub(crate) const TOPLEVEL_RECOVERY_SET: [TokenKind; 3] =
+    [TokenKind::FnKw, TokenKind::StructKw, TokenKind::ModKw];
 /// ブロック内で回復可能なトークンの集合
-pub(crate) const BLOCK_RECOVERY_SET: [TokenKind; 3] =
-    [TokenKind::LetKw, TokenKind::FnKw, TokenKind::ModKw];
+pub(crate) const BLOCK_RECOVERY_SET: [TokenKind; 4] = [
+    TokenKind::LetKw,
+    TokenKind::StructKw,
+    TokenKind::FnKw,
+    TokenKind::ModKw,
+];
 
 impl<'l, 'input> Parser<'l, 'input> {
     /// CSTを構築するパーサーを作成します。

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -1,5 +1,4 @@
 //! Syntax tree definitions for the Nail language.
-
 use lexer::TokenKind;
 use num_derive::{FromPrimitive, ToPrimitive};
 use num_traits::{FromPrimitive, ToPrimitive};
@@ -65,6 +64,8 @@ pub enum SyntaxKind {
     // ---item nodes---
     /// `fn IDENT(ParamList) -> ReturnType BlockExpr`
     FunctionDef,
+    /// `struct IDENT { TupleFieldList | RecordFieldList }`
+    StructDef,
     /// `mod IDENT { ItemList }`
     Module,
     /// `use Path;`
@@ -79,6 +80,14 @@ pub enum SyntaxKind {
     ArgList,
     /// `EXPR`
     Arg,
+    /// `(TupleField, TupleField, ...)`
+    TupleFieldList,
+    /// `TYPE`
+    TupleField,
+    /// `{ RecordField, RecordField, ... }`
+    RecordFieldList,
+    /// `IDENT: TYPE`
+    RecordField,
     /// `TYPE`
     Type,
     /// fn foo() -> i32 { ... }
@@ -96,6 +105,8 @@ pub enum SyntaxKind {
     // ---item keywords---
     /// `fn`
     FnKw,
+    /// `struct`
+    StructKw,
     /// `mod`
     ModKw,
     /// `use`
@@ -208,6 +219,7 @@ impl From<TokenKind> for SyntaxKind {
     fn from(token_kind: TokenKind) -> Self {
         match token_kind {
             TokenKind::FnKw => Self::FnKw,
+            TokenKind::StructKw => Self::StructKw,
             TokenKind::ModKw => Self::ModKw,
             TokenKind::UseKw => Self::UseKw,
 

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -65,6 +65,10 @@ pub enum SyntaxKind {
     /// `fn IDENT(ParamList) -> ReturnType BlockExpr`
     FunctionDef,
     /// `struct IDENT { TupleFieldList | RecordFieldList }`
+    ///
+    /// Represents a structure definition,
+    /// which can either be a tuple-like struct (e.g., `struct IDENT(TupleFieldList);`) or
+    /// a classic C-like struct (e.g., `struct IDENT { RecordFieldList }`).
     StructDef,
     /// `mod IDENT { ItemList }`
     Module,


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added support for the 'struct' keyword across lexer, parser, and syntax components.
- Implemented parsing logic for struct definitions including empty, tuple, and record fields.
- Updated error messages and recovery sets to accommodate the new 'struct' keyword.
- Added tests for lexing and parsing 'struct' definitions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>token_kind.rs</strong><dd><code>Add support for 'struct' keyword in lexer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
crates/lexer/src/token_kind.rs

<li>Added <code>StructKw</code> token kind for recognizing 'struct' keyword.<br> <li> Updated display implementation to include 'struct' keyword.<br> <li> Added test for lexing 'struct' keyword.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ktanaka101/nail/pull/552/files#diff-bcb62f578e62355cfdb4c7340ec21652d3eea5b699a1e9e83d45fd66ce574cb9">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expr.rs</strong><dd><code>Update error messages to include 'struct' keyword</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
crates/parser/src/grammar/expr.rs

- Updated error messages to include 'struct' in expected tokens.



</details>
    

  </td>
  <td><a href="https://github.com/ktanaka101/nail/pull/552/files#diff-23c55d79f5a2b3571f0cec3b94278ec4c177a327824f74108fb158dcf04cacbb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stmt.rs</strong><dd><code>Implement parsing logic for 'struct' definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
crates/parser/src/grammar/stmt.rs

<li>Added parsing support for 'struct' definitions including empty, tuple, <br>and record fields.<br> <li> Added comprehensive tests for various struct parsing scenarios.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ktanaka101/nail/pull/552/files#diff-cfbb474454583ce2a442cb0f4ae78b796a3dc8a961a4fb6aa4d28b0e8aa5a20a">+456/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>toplevel.rs</strong><dd><code>Extend top-level parsing to include 'struct' keyword</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
crates/parser/src/grammar/toplevel.rs

<li>Added parsing support for 'struct' at the top level.<br> <li> Updated error messages to include 'struct' in expected tokens.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ktanaka101/nail/pull/552/files#diff-22f9ba4c911179c394f2a4882cb540dc4e4b450616e270224d31b4cc31eb31dd">+72/-8</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Define syntax kinds for struct definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
crates/syntax/src/lib.rs

<li>Added <code>StructDef</code>, <code>TupleFieldList</code>, <code>TupleField</code>, <code>RecordFieldList</code>, and <br><code>RecordField</code> to <code>SyntaxKind</code>.<br> <li> Added <code>StructKw</code> to <code>SyntaxKind</code> conversions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ktanaka101/nail/pull/552/files#diff-0fd80900004ac2f41fbb615ba8406a29c68bac2dbacdfc83998623abda04aefb">+13/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Update parser recovery sets to include 'struct'</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
crates/parser/src/lib.rs

- Updated recovery sets to include 'struct' keyword.



</details>
    

  </td>
  <td><a href="https://github.com/ktanaka101/nail/pull/552/files#diff-5b592ca71efe7505ec19c835d345b3a4c325285cee3d4f752d984d909eddebf6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

