### PR TITLE
Refactor AST and HIR with Enhanced Traits and Pointer Methods


### DIFF
--- a/crates/ast/src/ast_node.rs
+++ b/crates/ast/src/ast_node.rs
@@ -7,7 +7,7 @@ pub trait Ast {}
 /// ASTノード
 ///
 /// ASTノードはASTトークンの集合であり、ASTノードはASTトークンを持つことができます。
-pub trait AstNode: Ast {
+pub trait AstNode: Ast + Sized {
     /// 指定した[SyntaxKind]にキャスト可能かどうかを返します。
     fn can_cast(kind: SyntaxKind) -> bool;
 
@@ -35,6 +35,22 @@ pub trait AstNode: Ast {
         Self: Sized,
     {
         Self::cast(self.syntax().clone_subtree()).unwrap()
+    }
+
+    /// ASTポインタからASTノードを取得します。
+    /// `syntax_node`がASTノードを持っていない場合は[None]を返します。
+    #[inline]
+    fn from_ast_ptr(
+        ptr: &crate::AstPtr<Self>,
+        syntax_node: &rowan::SyntaxNode<syntax::NailLanguage>,
+    ) -> Option<Self> {
+        Self::cast(ptr.node.to_node(syntax_node))
+    }
+
+    /// ASTポインタを返します。
+    #[inline]
+    fn to_ast_ptr(&self) -> crate::AstPtr<Self> {
+        crate::AstPtr::new(self)
     }
 }
 

--- a/crates/ast/src/lib.rs
+++ b/crates/ast/src/lib.rs
@@ -66,10 +66,17 @@ unsafe impl<T: AstNode> Send for AstPtr<T> {}
 unsafe impl<T: AstNode> Sync for AstPtr<T> {}
 impl<T: AstNode> AstPtr<T> {
     /// 新しいASTポインタを作成します。
+    #[inline]
     pub fn new(node: &T) -> Self {
         Self {
             node: SyntaxNodePtr::new(node.syntax()),
             _ty: PhantomData,
         }
+    }
+
+    /// ASTポインタを元にASTノードを取得します。
+    #[inline]
+    pub fn to_ast_node(&self, syntax_node: &SyntaxNode) -> Option<T> {
+        T::from_ast_ptr(self, syntax_node)
     }
 }

--- a/crates/ast/src/nodes.rs
+++ b/crates/ast/src/nodes.rs
@@ -5,6 +5,14 @@ use crate::{
     tokens,
 };
 
+/// 式に変換可能なASTノードを定義します。
+pub trait ToExpr: AstNode {
+    /// Expr ASTノードに変換します。
+    fn to_expr(&self) -> Expr {
+        Expr::cast(self.syntax().clone()).unwrap()
+    }
+}
+
 /// ASTノードを定義します。
 ///
 /// # Example
@@ -202,6 +210,22 @@ impl AstNode for Expr {
         }
     }
 }
+
+impl ToExpr for BinaryExpr {}
+impl ToExpr for Literal {}
+impl ToExpr for ParenExpr {}
+impl ToExpr for UnaryExpr {}
+impl ToExpr for PathExpr {}
+impl ToExpr for CallExpr {}
+impl ToExpr for BlockExpr {}
+impl ToExpr for IfExpr {}
+impl ToExpr for ReturnExpr {}
+impl ToExpr for LoopExpr {}
+impl ToExpr for ContinueExpr {}
+impl ToExpr for BreakExpr {}
+impl ToExpr for WhileExpr {}
+impl ToExpr for RecordExpr {}
+impl ToExpr for FieldExpr {}
 
 /// ステートメントノード
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/hir/src/body.rs
+++ b/crates/hir/src/body.rs
@@ -260,9 +260,7 @@ impl<'a> BodyLower<'a> {
             .params()
             .enumerate()
             .map(|(pos, param)| {
-                let name = param
-                    .name()
-                    .map(|name| Name::new(db, name.name().to_string()));
+                let name = param.name().map(|name| Name::new_from_ident(db, name));
                 let ty = self.lower_path_type(db, param.ty());
                 Param::new(self.hir_file_db, name, ty, pos, param.mut_token().is_some())
             })

--- a/crates/hir/src/body.rs
+++ b/crates/hir/src/body.rs
@@ -320,9 +320,7 @@ impl<'a> BodyLower<'a> {
 
     /// 構造体のHIRを構築します。
     fn lower_struct(&mut self, db: &dyn HirMasterDatabase, def: ast::StructDef) -> Option<Struct> {
-        let name = def
-            .name()
-            .map(|name| Name::new(db, name.name().to_string()))?;
+        let name = def.name().map(|name| Name::new_from_ident(db, name))?;
 
         let kind = match def.to_kind() {
             ast::StructKind::Tuple(fileds) => StructKind::Tuple(
@@ -335,7 +333,7 @@ impl<'a> BodyLower<'a> {
                 fields
                     .fields()
                     .map(|field| {
-                        let name = Name::new(db, field.name().unwrap().name().to_string());
+                        let name = Name::new_from_ident(db, field.name().unwrap());
                         let ty = self.lower_path_type(db, field.ty());
                         RecordField { name, ty }
                     })
@@ -361,7 +359,7 @@ impl<'a> BodyLower<'a> {
         ast_module: ast::Module,
     ) -> Option<Module> {
         if let Some(name) = ast_module.name() {
-            let module_name = Name::new(db, name.name().to_string());
+            let module_name = Name::new_from_ident(db, name);
 
             let module_kind = if let Some(item_list) = ast_module.items() {
                 let mut items = vec![];
@@ -388,10 +386,10 @@ impl<'a> BodyLower<'a> {
         match use_path.as_slice() {
             [] => unreachable!("use path should not be empty"),
             [path @ .., name] => {
-                let name = Name::new(db, name.name().unwrap().name().to_string());
+                let name = Name::new_from_ident(db, name.name().unwrap());
                 let segments = path
                     .iter()
-                    .map(|segment| Name::new(db, segment.name().unwrap().name().to_string()))
+                    .map(|segment| Name::new_from_ident(db, segment.name().unwrap()))
                     .collect::<Vec<_>>();
                 let path = Path::new(db, segments.clone());
                 let full_path = Path::new(db, {
@@ -448,10 +446,7 @@ impl<'a> BodyLower<'a> {
                                     segments
                                         .iter()
                                         .map(|segment| {
-                                            Name::new(
-                                                db,
-                                                segment.name().unwrap().name().to_string(),
-                                            )
+                                            Name::new_from_ident(db, segment.name().unwrap())
                                         })
                                         .collect(),
                                 );
@@ -484,7 +479,7 @@ impl<'a> BodyLower<'a> {
         let result = match ast_stmt {
             ast::Stmt::Let(def) => {
                 let expr = self.lower_expr(db, def.value());
-                let name = Name::new(db, def.name()?.name().to_owned());
+                let name = Name::new_from_ident(db, def.name()?);
                 let mutable = def.mut_token().is_some();
 
                 let binding = Binding {
@@ -665,7 +660,7 @@ impl<'a> BodyLower<'a> {
                 .path()
                 .unwrap()
                 .segments()
-                .map(|segment| Name::new(db, segment.name().unwrap().name().to_string()))
+                .map(|segment| Name::new_from_ident(db, segment.name().unwrap()))
                 .collect(),
         );
         let symbol = self.lookup_path(db, path);
@@ -903,7 +898,7 @@ impl<'a> BodyLower<'a> {
                 .path()
                 .unwrap()
                 .segments()
-                .map(|segment| Name::new(db, segment.name().unwrap().name().to_string()))
+                .map(|segment| Name::new_from_ident(db, segment.name().unwrap()))
                 .collect(),
         );
         let symbol = Symbol::MissingExpr {
@@ -915,7 +910,7 @@ impl<'a> BodyLower<'a> {
             .unwrap()
             .fields()
             .map(|field| {
-                let name = Name::new(db, field.name().unwrap().name().to_string());
+                let name = Name::new_from_ident(db, field.name().unwrap());
                 let value = self.lower_expr(db, field.value());
                 RecordFieldExpr { name, value }
             })

--- a/crates/hir/src/body.rs
+++ b/crates/hir/src/body.rs
@@ -162,7 +162,7 @@ impl HirFileDatabase {
 
         self.ast_by_function
             .get(&function)
-            .and_then(|ptr| ast::FunctionDef::cast(ptr.node.to_node(&syntax_node)))
+            .and_then(|ptr| ptr.to_ast_node(&syntax_node))
     }
 
     pub fn function_ast_ptr_by_function(
@@ -278,7 +278,7 @@ impl<'a> BodyLower<'a> {
         };
 
         let function = Function::new(db, name, params, param_by_name, return_type);
-        let def_ptr = AstPtr::new(&def);
+        let def_ptr = def.to_ast_ptr();
 
         self.hir_file_db.functions.push(function);
         self.source_by_function.insert(
@@ -313,7 +313,7 @@ impl<'a> BodyLower<'a> {
             .insert(function, FunctionBodyId(body_expr));
         self.hir_file_db
             .function_body_by_ast_block
-            .insert(AstPtr::new(&ast_block), FunctionBodyId(body_expr));
+            .insert(ast_block.to_ast_ptr(), FunctionBodyId(body_expr));
 
         Some(function)
     }
@@ -470,7 +470,7 @@ impl<'a> BodyLower<'a> {
                     ty.clone(),
                     TypeSource {
                         file: self.file,
-                        value: AstPtr::new(&path_type),
+                        value: path_type.to_ast_ptr(),
                     },
                 );
 
@@ -594,7 +594,7 @@ impl<'a> BodyLower<'a> {
             expr_id,
             InFile {
                 file: self.file,
-                value: AstPtr::new(ast_expr),
+                value: ast_expr.to_ast_ptr(),
             },
         );
 
@@ -615,7 +615,7 @@ impl<'a> BodyLower<'a> {
             expr_id,
             InFile {
                 file: self.file,
-                value: AstPtr::new(from_ast_expr),
+                value: from_ast_expr.to_ast_ptr(),
             },
         );
 

--- a/crates/hir/src/body.rs
+++ b/crates/hir/src/body.rs
@@ -2,13 +2,13 @@ mod scopes;
 
 use std::collections::HashMap;
 
-use ast::AstNode;
+use ast::{AstNode, AstPtr};
 use la_arena::{Arena, Idx};
 
 use crate::{
     body::scopes::ExprScopes,
     item::{ParamData, RecordField, StructKind},
-    AstPtr, BinaryOp, Binding, Block, Expr, ExprSource, Function, FunctionSource, HirFileSourceMap,
+    BinaryOp, Binding, Block, Expr, ExprSource, Function, FunctionSource, HirFileSourceMap,
     HirMasterDatabase, InFile, Item, Literal, Module, ModuleKind, NailFile, NailGreenNode, Name,
     NameSolutionPath, Param, Path, RecordFieldExpr, Stmt, Struct, Symbol, Type, TypeSource,
     UnaryOp, UseItem,

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -520,6 +520,12 @@ pub struct Name {
     #[return_ref]
     pub text: String,
 }
+impl Name {
+    #[inline]
+    pub(crate) fn new_from_ident(db: &dyn HirMasterDatabase, ident: ast::Ident) -> Self {
+        Name::new(db, ident.name().to_string())
+    }
+}
 
 /// ステートメントです。
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -32,9 +32,9 @@ mod item;
 mod name_resolver;
 pub mod testing;
 
-use std::{collections::HashMap, marker::PhantomData};
+use std::collections::HashMap;
 
-use ast::AstNode;
+use ast::{AstNode, AstPtr};
 pub use body::{BindingId, BodyLower, ExprId, FunctionBodyId, HirFileDatabase};
 pub use db::{HirMasterDatabase, Jar};
 pub use input::{FixtureDatabase, NailFile, SourceDatabase, SourceDatabaseTrait};
@@ -378,36 +378,6 @@ pub fn build_green_node(db: &dyn HirMasterDatabase, nail_file: NailFile) -> Nail
     }
 
     NailGreenNode::new(db, nail_file, parse_result.green_node)
-}
-
-/// ASTノードのIDです。
-///
-/// 1ファイル内でユニークです。
-/// IDからASTを参照し、ファイル内における位置を取得することができます。
-#[derive(Debug, PartialEq, Eq, Hash)]
-pub struct AstPtr<T: AstNode> {
-    /// ASTノード
-    pub node: ast::SyntaxNodePtr,
-    _ty: PhantomData<T>,
-}
-impl<T: AstNode> Clone for AstPtr<T> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<T: AstNode> Copy for AstPtr<T> {}
-/// `AstPtr`はスレッドセーフです。
-/// `AstNode`はスレッドセーフではありませんが、`AstPtr`は`AstNode`の型情報のみを参照するだけのためスレッドセーフです。
-unsafe impl<T: AstNode> Send for AstPtr<T> {}
-unsafe impl<T: AstNode> Sync for AstPtr<T> {}
-impl<T: AstNode> AstPtr<T> {
-    /// 新しいASTポインタを作成します。
-    pub fn new(node: &T) -> Self {
-        Self {
-            node: ast::SyntaxNodePtr::new(node.syntax()),
-            _ty: PhantomData,
-        }
-    }
 }
 
 /// 式のAST位置です。


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Enhanced `AstNode` trait with new methods `from_ast_ptr` and `to_ast_ptr`, and added `Sized` constraint.
- Introduced `AstPtr` struct for AST node identification, with implementations for `Clone`, `Copy`, `Send`, and `Sync` traits.
- Added new traits `ToExpr`, `HasPath`, and `HasName` for AST nodes, and implemented them for various node types.
- Refactored HIR body code to utilize new `AstPtr` methods and simplified name and path handling.
- Removed redundant `AstPtr` definition from HIR library and added helper methods for `Name` and `Path` creation.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ast_node.rs</strong><dd><code>Enhance `AstNode` trait with pointer methods and `Sized` constraint.</code></dd></summary>
<hr>
      
crates/ast/src/ast_node.rs

<li>Added <code>from_ast_ptr</code> and <code>to_ast_ptr</code> methods to <code>AstNode</code> trait.<br> <li> Modified <code>AstNode</code> trait to include <code>Sized</code> constraint.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ktanaka101/nail/pull/649/files#diff-f52f01037e3484852f1b933830b0515f6b0a540d4edf1b89d250e2504e685ff2">+17/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Introduce `AstPtr` struct for AST node identification.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
crates/ast/src/lib.rs

<li>Added <code>AstPtr</code> struct for AST node identification.<br> <li> Implemented <code>Clone</code>, <code>Copy</code>, <code>Send</code>, and <code>Sync</code> traits for <code>AstPtr</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ktanaka101/nail/pull/649/files#diff-1b1ac56cab86b690b35d4945fc66474b13dba6dd7f08ed79d28fd2f020f62b89">+39/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>nodes.rs</strong><dd><code>Define and implement new traits for AST nodes.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
crates/ast/src/nodes.rs

<li>Added <code>ToExpr</code>, <code>HasPath</code>, and <code>HasName</code> traits.<br> <li> Implemented new traits for various AST node types.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ktanaka101/nail/pull/649/files#diff-955dab889c63a6d0779b1396611351fac37bdec09a56b0b9e951e658ad5e2bf0">+63/-34</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>body.rs</strong><dd><code>Refactor HIR body to utilize new `AstPtr` methods and helpers.</code></dd></summary>
<hr>
      
crates/hir/src/body.rs

<li>Refactored to use new <code>AstPtr</code> methods.<br> <li> Simplified name and path handling using new helper methods.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ktanaka101/nail/pull/649/files#diff-c2f62ca80e8dfe7461bbe5d9dc988e8bffe190e0f993a1ae37f6116522bd1ef0">+35/-88</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Cleanup and add helper methods for `Name` and `Path`.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
crates/hir/src/lib.rs

<li>Removed redundant <code>AstPtr</code> definition.<br> <li> Added helper methods for <code>Name</code> and <code>Path</code> creation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ktanaka101/nail/pull/649/files#diff-9ded74602cbdce03cc0b20f094e733658a7b43d14ffe0f9167bc79a0851e7e53">+42/-32</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

