### PR TITLE
Modify the compile task to skip test execution

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -43,7 +43,7 @@ cm_run_task ${SUBCOMMAND_PREFIX}_${1}
 [tasks.nail_compile]
 private = true
 command = "cargo"
-args = ["nextest", "run", "--workspace", "--locked"]
+args = ["build", "--workspace", "--locked"]
 install_crate = false
 
 [tasks.nail_compile-ci]


### PR DESCRIPTION
close #851 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- プロジェクトのビルドプロセスを強化するため、`nail_compile`タスクがテスト実行からビルドに変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->