### PR TITLE
Add support for Array Expr in the Parser

### DIFF
--- a/crates/parser/src/grammar/expr.rs
+++ b/crates/parser/src/grammar/expr.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// 式の最初に現れる可能性があるトークンの集合
-pub(super) const EXPR_FIRST: [TokenKind; 17] = [
+pub(super) const EXPR_FIRST: [TokenKind; 18] = [
     TokenKind::StringLiteral,
     TokenKind::CharLiteral(false),
     TokenKind::CharLiteral(true),
@@ -21,6 +21,7 @@ pub(super) const EXPR_FIRST: [TokenKind; 17] = [
     TokenKind::Minus,
     TokenKind::LParen,
     TokenKind::LCurly,
+    TokenKind::LBrace,
     TokenKind::IfKw,
     TokenKind::ReturnKw,
     TokenKind::LoopKw,
@@ -328,6 +329,7 @@ fn parse_array_expr(parser: &mut Parser) -> CompletedNodeMarker {
 
     parser.expect_on_block(TokenKind::LBrace);
 
+    // First element or empty array
     if parser.at_set_no_expected(&EXPR_FIRST) {
         parse_expr(parser);
     } else {
@@ -1041,6 +1043,36 @@ mod tests {
                     ArrayExpr@0..2
                       LBrace@0..1 "["
                       RBrace@1..2 "]"
+            "#]],
+        );
+    }
+
+    #[test]
+    fn parse_array_expr_nested() {
+        check_debug_tree_in_block(
+            r#"[[[1], 2], 3]"#,
+            expect![[r#"
+                SourceFile@0..13
+                  ExprStmt@0..13
+                    ArrayExpr@0..13
+                      LBrace@0..1 "["
+                      ArrayExpr@1..9
+                        LBrace@1..2 "["
+                        ArrayExpr@2..5
+                          LBrace@2..3 "["
+                          Literal@3..4
+                            Integer@3..4 "1"
+                          RBrace@4..5 "]"
+                        Comma@5..6 ","
+                        Whitespace@6..7 " "
+                        Literal@7..8
+                          Integer@7..8 "2"
+                        RBrace@8..9 "]"
+                      Comma@9..10 ","
+                      Whitespace@10..11 " "
+                      Literal@11..12
+                        Integer@11..12 "3"
+                      RBrace@12..13 "]"
             "#]],
         );
     }

--- a/crates/parser/src/grammar/stmt.rs
+++ b/crates/parser/src/grammar/stmt.rs
@@ -424,7 +424,7 @@ mod tests {
                     Error@8..10
                       Integer@8..10 "10"
                 error at 8..10: expected '=', but found integerLiteral
-                error at 8..10: expected integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '(', '{', 'if', 'return', 'loop', 'continue', 'break' or 'while'
+                error at 8..10: expected integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '[', '(', '{', 'if', 'return', 'loop', 'continue', 'break' or 'while'
             "#]],
         )
     }
@@ -471,7 +471,7 @@ mod tests {
                       Path@16..17
                         PathSegment@16..17
                           Ident@16..17 "a"
-                error at 8..11: expected integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '(', '{', 'if', 'return', 'loop', 'continue', 'break' or 'while', but found 'let'
+                error at 8..11: expected integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '[', '(', '{', 'if', 'return', 'loop', 'continue', 'break' or 'while', but found 'let'
             "#]],
         );
     }
@@ -1047,7 +1047,7 @@ mod tests {
                     Error@16..17
                       RCurly@16..17 "}"
                 error at 13..15: expected identifier or '}', but found integerLiteral
-                error at 16..17: expected '+', '-', '*', '/', '==', '!=', '>', '<', '>=', '<=', '=', ';', 'let', 'fn', 'struct', 'mod', integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '!', '(', '{', 'if', 'return', 'loop', 'continue', 'break' or 'while', but found '}'
+                error at 16..17: expected '+', '-', '*', '/', '==', '!=', '>', '<', '>=', '<=', '=', ';', 'let', 'fn', 'struct', 'mod', integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '!', '[', '(', '{', 'if', 'return', 'loop', 'continue', 'break' or 'while', but found '}'
             "#]],
         );
     }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -162,7 +162,7 @@ mod tests {
                               Ident@11..16 "hello"
                       Whitespace@16..17 " "
                       RCurly@17..18 "}"
-                error at 9..10: expected '}', 'let', 'fn', 'struct', 'mod', integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '(', '{', 'if', 'return', 'loop', 'continue', 'break' or 'while', but found '/'
+                error at 9..10: expected '}', 'let', 'fn', 'struct', 'mod', integerLiteral, charLiteral, stringLiteral, 'true', 'false', identifier, '-', '!', '[', '(', '{', 'if', 'return', 'loop', 'continue', 'break' or 'while', but found '/'
             "#]],
         );
     }

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -30,6 +30,8 @@ pub enum SyntaxKind {
     // ---expression nodes---
     /// `INTEGER_LITERAL` | `CHAR_LITERAL` | `STRING_LITERAL` | `true` | `false`
     Literal,
+    /// `[EXPR, ...]`
+    ArrayExpr,
     /// `(EXPR)`
     ParenExpr,
     /// `EXPR + EXPR`, `EXPR - EXPR`, ...

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -30,7 +30,7 @@ pub enum SyntaxKind {
     // ---expression nodes---
     /// `INTEGER_LITERAL` | `CHAR_LITERAL` | `STRING_LITERAL` | `true` | `false`
     Literal,
-    /// `[EXPR, ...]`
+    /// `[EXPR, ...]` ex. `[1, 2, 3]`, `[x, y]`
     ArrayExpr,
     /// `(EXPR)`
     ParenExpr,


### PR DESCRIPTION
refs #886 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
  - 配列リテラルを処理するための新しいパース機能を追加しました。
  - 配列式を表すためにASTに新しいバリアント`ArrayExpr`を導入しました。

- **バグ修正**
  - パース中のエラーメッセージを改善し、より具体的なフィードバックを提供しました。

- **テスト**
  - 配列式のパースに関する新しいテストケースを追加し、さまざまなシナリオをカバーしました。
  - 関数および構造体定義に関するテストを拡張し、エラーメッセージを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->