### PR TITLE
build: use mold linker for faster linking

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(target_os = "linux")']
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
+# Use the mold linker to speed up build times on Linux
 [target.'cfg(target_os = "linux")']
 rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt update && apt -y upgrade && \
   zstd \
   libzstd-dev \
   # Use mold for building
-  mold
+  mold=1.10.1+dfsg-1
 
 # Environment variables are required by llvm-sys
 # LLVM-18.0 needs LLVM_SYS_180_STRICT_VERSIONING=180, LLVM_SYS_181_PREFIX=/usr/lib/llvm-18/

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,9 @@ RUN apt update && apt -y upgrade && \
   # llvm dependency (99bc465)
   zlib1g-dev \
   zstd \
-  libzstd-dev
+  libzstd-dev \
+  # Use mold for building
+  mold
 
 # Environment variables are required by llvm-sys
 # LLVM-18.0 needs LLVM_SYS_180_STRICT_VERSIONING=180, LLVM_SYS_181_PREFIX=/usr/lib/llvm-18/


### PR DESCRIPTION
Close #1011

- Add .cargo/config.toml to use mold linker on Linux
- Install mold package in Docker environment
